### PR TITLE
ARM Builds

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest, macos-13]
 
     steps:
     - uses: actions/checkout@v4
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.20.0
+      uses: pypa/cibuildwheel@v2.22.0
 
     - uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
waiting: https://gitlab.kitware.com/vtk/vtk/-/issues/19605
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

Digits, jetson thor, cuda arm laptops are coming

windows arm q2 2025: https://github.com/github/roadmap/issues/1098

ubuntu 20.04 is deprecated from today