### PR TITLE
Fix NAN mesh creation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
   autoupdate_schedule: quarterly
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.4
+  rev: v0.11.11
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]
@@ -39,7 +39,7 @@ repos:
     args: [--autofix, --indent, '2']
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v20.1.0
+  rev: v20.1.5
   hooks:
   - id: clang-format
 
@@ -55,7 +55,7 @@ repos:
 
 # this validates our github workflow files
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.32.1
+  rev: 0.33.0
   hooks:
   - id: check-github-workflows
 

--- a/src/pyacvd/clustering.py
+++ b/src/pyacvd/clustering.py
@@ -1,7 +1,6 @@
 """Point based clustering module"""
 
 import logging
-import warnings
 from typing import Any, Optional, Sequence, Tuple, TypeVar, Union, cast
 
 import numpy as np
@@ -321,9 +320,10 @@ class Clustering:
         cnorm[:, 1] = np.bincount(self.clusters, weights=n[:, 1] * self.area)
         cnorm[:, 2] = np.bincount(self.clusters, weights=n[:, 2] * self.area)
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            cnorm /= ((cnorm * cnorm).sum(1) ** 0.5).reshape((-1, 1))
+        # normalize
+        cnorm_weight = ((cnorm * cnorm).sum(1) ** 0.5).reshape(-1, 1)
+        cnorm_weight[cnorm_weight == 0] = 1
+        cnorm /= cnorm_weight
 
         return cnorm
 

--- a/src/pyacvd/clustering.py
+++ b/src/pyacvd/clustering.py
@@ -277,7 +277,9 @@ class Clustering:
 
         return self.mesh.plot(notebook=False, scalars=colors, rng=rng, **kwargs)
 
-    def create_mesh(self, moveclus: bool = True, flipnorm: bool = True) -> pv.PolyData:
+    def create_mesh(
+        self, moveclus: bool = True, flipnorm: bool = True, clean: bool = True
+    ) -> pv.PolyData:
         """
         Generate mesh from clusters.
 
@@ -288,6 +290,13 @@ class Clustering:
         flipnorm : bool, default: True
             Ensure the normals of the clustered mesh match the normals of the
             original mesh.
+        clean : bool, default: True
+            Clean the mesh. This removes any unused points.
+
+        Returns
+        -------
+        pyvista.PolyData
+            Mesh from clusters.
 
         """
         if self.clusters is None or self.nclus is None:
@@ -303,6 +312,8 @@ class Clustering:
         self.remesh = create_mesh(
             self.mesh, self.area, self.clusters, cnorm, self.nclus, moveclus, flipnorm
         )
+        if clean:
+            self.remesh = self.remesh.clean()
         return self.remesh
 
     @property

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -27,8 +27,11 @@ except:
 def test_bunny() -> None:
     clus = pyacvd.Clustering(bunny)
     clus.cluster(5000)
-    remesh = clus.create_mesh()
+    remesh = clus.create_mesh(clean=False)
     assert remesh.n_points == 5000
+
+    remesh = clus.create_mesh(clean=True)
+    assert remesh.n_points == remesh.clean().n_points
 
 
 def test_cylinder() -> None:


### PR DESCRIPTION
Resolve #65 by fixing the edge case where some clusters have zero members and these empty clusters have null points. As a byproduct, these disconnected points are excluded now by cleaning the mesh using [pyvista.PolyDataFilters.clean](https://docs.pyvista.org/api/core/_autosummary/pyvista.PolyDataFilters.clean.html).
