### PR TITLE
Add ARM64 build

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, ubuntu-22.04-arm, windows-latest, macos-13, macos-14]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ test-command = "pytest {project}/tests"
 test-requires = "pytest"
 test-skip = "*-macosx_arm64"
 
+[tool.cibuildwheel.linux]
+# Use manylinux_2_28 for aarch64 to support VTK 9.5 wheels
+manylinux-aarch64-image = "manylinux_2_28"
+
 [tool.cibuildwheel.macos]
 archs = ["native"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ classifiers = [
 dependencies = [
   "numpy",
   "pyvista>=0.37.0",
-  'pykdtree'
+  "pykdtree",
+  # VTK < 9.5 doesn't have prebuilt ARM64 wheels
+  "vtk~=9.5 ; sys_platform == 'linux' and platform_machine == 'aarch64'"
 ]
 description = "Uniformly remeshes surface meshes"
 keywords = ["vtk", "uniform", "meshing", "remeshing", "acvd"]


### PR DESCRIPTION
arm64 wheels require vtk ~= 9.5 at the moment, because previous versions don't have prebuilt arm64 wheels. Maybe we can help upstream get there though: [vtk#19605](https://gitlab.kitware.com/vtk/vtk/-/issues/19605).

Inspired by https://github.com/pyvista/pyacvd/pull/61