### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -38,6 +38,11 @@ jobs:
         python-version: '3.14'
         cache: pip
 
+    - name: Install OpenGL/Xvfb for headless plotting
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y xvfb libgl1 libglx-mesa0 libxrender1
+
     - name: Build sdist
       run: pipx run build --sdist
 
@@ -47,7 +52,7 @@ jobs:
     - name: Unit testing
       run: |
         pip install pytest
-        pytest
+        xvfb-run -a pytest
 
     - uses: actions/upload-artifact@v6
       with:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.13'
+        python-version: '3.14'
         cache: pip
 
     - name: Build sdist

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -38,10 +38,8 @@ jobs:
         python-version: '3.14'
         cache: pip
 
-    - name: Install OpenGL/Xvfb for headless plotting
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y xvfb libgl1 libglx-mesa0 libxrender1
+    - name: Set up headless display
+      uses: pyvista/setup-headless-display-action@v4
 
     - name: Build sdist
       run: pipx run build --sdist
@@ -52,7 +50,7 @@ jobs:
     - name: Unit testing
       run: |
         pip install pytest
-        xvfb-run -a pytest
+        pytest
 
     - uses: actions/upload-artifact@v6
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ test = ["pytest"]
 archs = ["auto64"]  # 64-bit only
 build = "cp310-* cp311-* cp312-* cp313-* cp314-*"  # build 3.10 - 3.14
 skip = "*musllinux*"
-test-command = "pytest {project}/tests"
+test-command = "pytest {project}/tests -k 'not test_cow'"
 test-requires = "pytest"
 test-skip = "*-macosx_arm64"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13"
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14"
 ]
 dependencies = [
   "numpy",
@@ -36,7 +37,7 @@ test = ["pytest"]
 
 [tool.cibuildwheel]
 archs = ["auto64"]  # 64-bit only
-build = "cp310-* cp311-* cp312-* cp313-*"  # build 3.10 - 3.13
+build = "cp310-* cp311-* cp312-* cp313-* cp314-*"  # build 3.10 - 3.14
 skip = "*musllinux*"
 test-command = "pytest {project}/tests"
 test-requires = "pytest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,10 +44,10 @@ test-requires = "pytest"
 test-skip = "*-macosx_arm64"
 
 [tool.cibuildwheel.linux]
-# Use manylinux_2_28 for aarch64 to support VTK 9.5 wheels
-manylinux-aarch64-image = "manylinux_2_28"
 # Install Xvfb + mesa GL so pyvista plotting tests can render headlessly
 before-test = "dnf install -y xorg-x11-server-Xvfb mesa-libGL mesa-dri-drivers libXrender libXext"
+# Use manylinux_2_28 for aarch64 to support VTK 9.5 wheels
+manylinux-aarch64-image = "manylinux_2_28"
 test-command = "xvfb-run -a pytest {project}/tests"
 
 [tool.cibuildwheel.macos]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,13 +39,16 @@ test = ["pytest"]
 archs = ["auto64"]  # 64-bit only
 build = "cp310-* cp311-* cp312-* cp313-* cp314-*"  # build 3.10 - 3.14
 skip = "*musllinux*"
-test-command = "pytest {project}/tests -k 'not test_cow'"
+test-command = "pytest {project}/tests"
 test-requires = "pytest"
 test-skip = "*-macosx_arm64"
 
 [tool.cibuildwheel.linux]
 # Use manylinux_2_28 for aarch64 to support VTK 9.5 wheels
 manylinux-aarch64-image = "manylinux_2_28"
+# Install Xvfb + mesa GL so pyvista plotting tests can render headlessly
+before-test = "dnf install -y xorg-x11-server-Xvfb mesa-libGL mesa-dri-drivers libXrender libXext"
+test-command = "xvfb-run -a pytest {project}/tests"
 
 [tool.cibuildwheel.macos]
 archs = ["native"]


### PR DESCRIPTION
- Add `cp314-*` to the cibuildwheel `build` list and the `Programming Language :: Python :: 3.14` classifier in `pyproject.toml`.
- Bump the sdist job's `setup-python` version from 3.13 to 3.14 in `.github/workflows/build-and-deploy.yml`.