### PR TITLE
Add `mesh.acvd.*` accessor for PyVista pipelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ Makefile
 cmake_install.cmake
 compile_commands.json
 .cache/*
+
+# uv / virtualenvs
+##################
+.venv/
+uv.lock

--- a/README.rst
+++ b/README.rst
@@ -20,12 +20,51 @@ Installation is straightforward using pip:
 
    $ pip install pyacvd
 
-*********
- Example
-*********
+**********
+ Examples
+**********
+
+PyVista accessor (recommended, ``pyvista >= 0.48``)
+===================================================
+
+Installing ``pyacvd`` registers an ``acvd`` namespace on every
+:class:`pyvista.PolyData`, so uniform remeshing slots straight into a
+PyVista pipeline. Once ``pyacvd`` is imported (or auto-discovered via
+PyVista's entry-point system) you can call ``mesh.acvd.<method>(...)``
+directly:
+
+.. code:: python
+
+   import pyacvd  # registers ``mesh.acvd``
+   from pyvista import examples
+
+   cow = examples.download_cow().triangulate()
+
+   # one-shot uniform remesh: subdivide → cluster → rebuild
+   remesh = cow.acvd.remesh(20000, subdivide=3)
+   remesh.plot(color='w', show_edges=True)
+
+The accessor never mutates the source mesh and always returns a fresh
+``pv.PolyData``. Available methods:
+
+-  ``mesh.acvd.remesh(n_clusters, subdivide=0, fast=False, ...)`` —
+   one-shot uniform remesh.
+
+-  ``mesh.acvd.clustering(weights=None, subdivide=0)`` — return a
+   configured :class:`pyacvd.Clustering` for fine-grained control
+   (plotting clusters, mixing fast/uniform clustering, etc.).
+
+-  ``mesh.acvd.cluster_ids(n_clusters, ...)`` — per-point cluster id
+   array, useful for visualization.
+
+-  ``mesh.acvd.subdivide(n)`` — linearly subdivide the surface.
+
+Classic ``Clustering`` API
+==========================
 
 This example remeshes a non-uniform quad mesh into a uniform triangular
-mesh.
+mesh. The classic API works on every supported PyVista version; the
+accessor above is a thin convenience layer on top.
 
 .. code:: python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ requires-python = ">=3.10"
 url = "https://github.com/pyvista/pyacvd"
 version = "0.4.dev0"
 
+[project.entry-points."pyvista.accessors"]
+acvd = "pyacvd._accessor"
+
 [project.optional-dependencies]
 test = ["pytest"]
 

--- a/src/pyacvd/__init__.py
+++ b/src/pyacvd/__init__.py
@@ -8,4 +8,14 @@ except PackageNotFoundError:
     __version__ = "unknown"
 
 
+# Register the ``acvd`` PyVista accessor on pyvista >= 0.48. The
+# classic ``Clustering`` API works on every supported pyvista version
+# (>= 0.37); the accessor is a thin convenience layer on top and is
+# silently skipped on older releases.
+import pyvista as _pv
+
+if hasattr(_pv, "register_dataset_accessor"):
+    from pyacvd import _accessor  # noqa: F401  (registers ``acvd``)
+
+
 __all__ = ["Clustering", "__version__"]

--- a/src/pyacvd/_accessor.py
+++ b/src/pyacvd/_accessor.py
@@ -1,0 +1,261 @@
+"""PyVista accessor for pyacvd.
+
+Importing this module registers the ``acvd`` namespace on
+:class:`pyvista.PolyData`, exposing pyacvd's uniform remeshing as
+``mesh.acvd.<method>(...)``. This module is imported automatically by
+``pyacvd`` when the installed PyVista is recent enough
+(``>= 0.48``); on older versions the accessor simply isn't registered
+and the classic :class:`pyacvd.Clustering` API still works.
+"""
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pyvista as pv
+
+from pyacvd.clustering import Clustering
+
+if TYPE_CHECKING:
+    from pyacvd.clustering import NDArray_FLOAT32_64
+
+
+@pv.register_dataset_accessor("acvd", pv.PolyData)
+class ACVDAccessor:
+    """ACVD uniform remeshing exposed as ``polydata.acvd.<method>(...)``.
+
+    The accessor wraps :class:`pyacvd.Clustering` so you can stay inside
+    a PyVista pipeline. :meth:`remesh` is the one-shot entry point;
+    :meth:`clustering` returns a configured :class:`~pyacvd.Clustering`
+    object when you need finer control (plotting clusters, inspecting
+    cluster centroids, mixing :meth:`~pyacvd.Clustering.cluster` with
+    :meth:`~pyacvd.Clustering.fast_cluster`).
+
+    The input mesh is triangulated on-the-fly when needed; the original
+    is never mutated.
+
+    Parameters
+    ----------
+    mesh : pyvista.PolyData
+        Surface mesh the accessor operates on.
+
+    Examples
+    --------
+    Uniformly remesh the Stanford bunny.
+
+    >>> from pyvista import examples
+    >>> import pyacvd  # noqa: F401  (registers the accessor)
+    >>> bunny = examples.download_bunny()
+    >>> remeshed = bunny.acvd.remesh(5000)
+    >>> remeshed.n_points
+    5000
+
+    Inspect clusters before generating the final mesh.
+
+    >>> import pyvista as pv
+    >>> import pyacvd  # noqa: F401
+    >>> cyl = pv.Cylinder().triangulate()
+    >>> clus = cyl.acvd.clustering(subdivide=3)
+    >>> _ = clus.cluster(500)
+    >>> clus.create_mesh().n_points
+    500
+
+    """
+
+    def __init__(self, mesh: pv.PolyData) -> None:
+        """Initialize the accessor with a source mesh."""
+        self._mesh = mesh
+
+    def _triangulated(self) -> pv.PolyData:
+        """Return an all-triangle copy of the wrapped mesh."""
+        if self._mesh.is_all_triangles:
+            return self._mesh.copy(deep=False)
+        return self._mesh.triangulate()
+
+    def clustering(
+        self,
+        weights: "NDArray_FLOAT32_64 | None" = None,
+        *,
+        subdivide: int = 0,
+    ) -> Clustering:
+        """Return a :class:`~pyacvd.Clustering` configured from this mesh.
+
+        Parameters
+        ----------
+        weights : numpy.ndarray, optional
+            Per-point weights forwarded to :class:`~pyacvd.Clustering`.
+            Larger weights pull cluster density toward those points.
+
+        subdivide : int, default: 0
+            If positive, perform this many linear subdivisions on the
+            (triangulated) mesh before clustering. Coarse meshes need
+            subdivision before they are dense enough for uniform
+            remeshing.
+
+        Returns
+        -------
+        pyacvd.Clustering
+            Clustering object operating on a triangulated copy of the
+            wrapped mesh; the source dataset is unchanged.
+
+        """
+        clus = Clustering(self._triangulated(), weights=weights)
+        if subdivide:
+            clus.subdivide(subdivide)
+        return clus
+
+    def remesh(
+        self,
+        n_clusters: int,
+        *,
+        subdivide: int = 0,
+        weights: "NDArray_FLOAT32_64 | None" = None,
+        maxiter: int = 100,
+        iso_try: int = 10,
+        fast: bool = False,
+        moveclus: bool = True,
+        flipnorm: bool = True,
+        clean: bool = True,
+    ) -> pv.PolyData:
+        """Uniformly remesh the surface using ACVD.
+
+        One-shot wrapper that triangulates (if needed), optionally
+        subdivides, clusters, and rebuilds a new uniform triangular
+        mesh.
+
+        Parameters
+        ----------
+        n_clusters : int
+            Target number of points (clusters) in the remeshed surface.
+
+        subdivide : int, default: 0
+            Linear subdivisions to apply before clustering. Required
+            when the input mesh is coarser than ``n_clusters``.
+
+        weights : numpy.ndarray, optional
+            Per-point weights forwarded to :class:`~pyacvd.Clustering`.
+
+        maxiter : int, default: 100
+            Maximum clustering iterations. Ignored when ``fast=True``.
+
+        iso_try : int, default: 10
+            Attempts to remove isolated clusters. Ignored when
+            ``fast=True``.
+
+        fast : bool, default: False
+            Use :meth:`~pyacvd.Clustering.fast_cluster` instead of the
+            uniform clustering. Faster, but cluster sizes are not
+            guaranteed to be uniform.
+
+        moveclus : bool, default: True
+            Move generated points onto the original surface.
+
+        flipnorm : bool, default: True
+            Align output face normals with the source mesh.
+
+        clean : bool, default: True
+            Run :meth:`pyvista.PolyData.clean` on the result.
+
+        Returns
+        -------
+        pyvista.PolyData
+            A new uniformly remeshed all-triangle surface. The source
+            mesh is not modified.
+
+        See Also
+        --------
+        clustering : Return the underlying :class:`~pyacvd.Clustering`
+            for fine-grained control.
+        cluster_ids : Compute cluster ids without rebuilding the
+            surface.
+
+        Examples
+        --------
+        >>> import pyvista as pv
+        >>> import pyacvd  # noqa: F401
+        >>> mesh = pv.Cylinder().triangulate()
+        >>> uniform = mesh.acvd.remesh(500, subdivide=3)
+        >>> uniform.n_points
+        500
+
+        """
+        clus = self.clustering(weights=weights, subdivide=subdivide)
+        if fast:
+            clus.fast_cluster(n_clusters)
+        else:
+            clus.cluster(n_clusters, maxiter=maxiter, iso_try=iso_try)
+        return clus.create_mesh(moveclus=moveclus, flipnorm=flipnorm, clean=clean)
+
+    def subdivide(self, nsub: int) -> pv.PolyData:
+        """Linearly subdivide the surface ``nsub`` times.
+
+        Parameters
+        ----------
+        nsub : int
+            Number of subdivisions.
+
+        Returns
+        -------
+        pyvista.PolyData
+            A new subdivided all-triangle surface.
+
+        Examples
+        --------
+        >>> import pyvista as pv
+        >>> import pyacvd  # noqa: F401
+        >>> mesh = pv.Cylinder().triangulate()
+        >>> mesh.acvd.subdivide(2).n_points > mesh.n_points
+        True
+
+        """
+        return self.clustering(subdivide=nsub).mesh
+
+    def cluster_ids(
+        self,
+        n_clusters: int,
+        *,
+        subdivide: int = 0,
+        weights: "NDArray_FLOAT32_64 | None" = None,
+        maxiter: int = 100,
+        iso_try: int = 10,
+        fast: bool = False,
+    ) -> np.ndarray:
+        """Compute cluster ids without building the remeshed surface.
+
+        Useful for visualizing clusters on the (subdivided) source mesh
+        or driving downstream analysis.
+
+        Parameters
+        ----------
+        n_clusters : int
+            Target number of clusters.
+
+        subdivide : int, default: 0
+            See :meth:`remesh`.
+
+        weights : numpy.ndarray, optional
+            See :meth:`remesh`.
+
+        maxiter : int, default: 100
+            See :meth:`remesh`.
+
+        iso_try : int, default: 10
+            See :meth:`remesh`.
+
+        fast : bool, default: False
+            See :meth:`remesh`.
+
+        Returns
+        -------
+        numpy.ndarray
+            ``int32`` array of length ``n_points`` of the (possibly
+            subdivided) mesh, with one cluster id per point. ``-1``
+            marks points that were not assigned to a cluster.
+
+        """
+        clus = self.clustering(weights=weights, subdivide=subdivide)
+        if fast:
+            return clus.fast_cluster(n_clusters)
+        return clus.cluster(n_clusters, maxiter=maxiter, iso_try=iso_try)
+
+
+__all__ = ["ACVDAccessor"]

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -1,0 +1,95 @@
+"""Tests for the pyacvd PyVista accessor (``mesh.acvd.*``)."""
+
+import numpy as np
+import pytest
+import pyvista as pv
+
+import pyacvd
+
+# The accessor is only available on pyvista >= 0.48; skip the whole
+# module otherwise so pyacvd remains usable on older releases.
+if not hasattr(pv, "register_dataset_accessor"):
+    pytest.skip("pyvista >= 0.48 required for the accessor", allow_module_level=True)
+
+
+@pytest.fixture
+def cylinder() -> pv.PolyData:
+    return pv.Cylinder().triangulate()
+
+
+def test_accessor_registered() -> None:
+    mesh = pv.Cylinder().triangulate()
+    assert hasattr(mesh, "acvd")
+    assert isinstance(mesh.acvd, pyacvd._accessor.ACVDAccessor)
+
+
+def test_accessor_cached_on_instance(cylinder: pv.PolyData) -> None:
+    # PyVista caches accessor instances per dataset.
+    assert cylinder.acvd is cylinder.acvd
+
+
+def test_remesh_returns_uniform_polydata(cylinder: pv.PolyData) -> None:
+    nclus = 500
+    remeshed = cylinder.acvd.remesh(nclus, subdivide=3)
+    assert isinstance(remeshed, pv.PolyData)
+    assert remeshed.n_points == nclus
+    assert remeshed.is_all_triangles
+
+
+def test_remesh_does_not_mutate_source(cylinder: pv.PolyData) -> None:
+    n_points_before = cylinder.n_points
+    n_cells_before = cylinder.n_cells
+    cylinder.acvd.remesh(500, subdivide=3)
+    assert cylinder.n_points == n_points_before
+    assert cylinder.n_cells == n_cells_before
+
+
+def test_remesh_triangulates_non_triangle_input() -> None:
+    # Cylinder() is quad/triangle mixed by default; the accessor should
+    # silently triangulate rather than raising.
+    quad_cyl = pv.Cylinder()
+    assert not quad_cyl.is_all_triangles
+    remeshed = quad_cyl.acvd.remesh(200, subdivide=3)
+    assert remeshed.n_points == 200
+
+
+def test_remesh_fast(cylinder: pv.PolyData) -> None:
+    remeshed = cylinder.acvd.remesh(200, subdivide=3, fast=True)
+    assert remeshed.is_all_triangles
+    # fast_cluster does not guarantee an exact match, but it should be
+    # in the same ballpark and never empty.
+    assert remeshed.n_points > 0
+
+
+def test_clustering_returns_clustering(cylinder: pv.PolyData) -> None:
+    clus = cylinder.acvd.clustering(subdivide=2)
+    assert isinstance(clus, pyacvd.Clustering)
+    # Subdivide grew the mesh; original is untouched.
+    assert clus.mesh.n_points > cylinder.n_points
+
+
+def test_subdivide_returns_polydata(cylinder: pv.PolyData) -> None:
+    out = cylinder.acvd.subdivide(2)
+    assert isinstance(out, pv.PolyData)
+    assert out.n_points > cylinder.n_points
+    assert out.is_all_triangles
+
+
+def test_cluster_ids_shape(cylinder: pv.PolyData) -> None:
+    clus = cylinder.acvd.clustering(subdivide=3)
+    ids = cylinder.acvd.cluster_ids(200, subdivide=3)
+    assert ids.dtype == np.int32
+    assert ids.shape == (clus.mesh.n_points,)
+    # Cluster ids should index a sensible range.
+    valid = ids[ids >= 0]
+    assert valid.min() >= 0
+    assert valid.max() < 200
+
+
+def test_remesh_weights_accepted(cylinder: pv.PolyData) -> None:
+    # Smoke test: weights of all ones should match the unweighted run
+    # closely enough to produce the requested cluster count.
+    n = pv.Cylinder().triangulate().subdivide(3).n_points
+    weights = np.ones(n, dtype=np.float64)
+    remeshed = cylinder.acvd.remesh(200, subdivide=3, weights=weights)
+    assert remeshed.n_points == 200


### PR DESCRIPTION
Using pyacvd today means dropping out of a PyVista pipeline to instantiate `Clustering`, subdivide, cluster, and rebuild. PyVista 0.48 added a dataset accessor protocol (the same pattern pandas and xarray use). This wires pyacvd into it so uniform remeshing is a one-liner:

```python
import pyacvd  # registers ``mesh.acvd``
remesh = mesh.acvd.remesh(20000, subdivide=3)
```

### What's exposed on `pv.PolyData.acvd`

- `remesh(n_clusters, *, subdivide=0, weights=None, fast=False, ...)`: one-shot uniform remesh. Auto-triangulates and never mutates the source mesh.
- `clustering(weights=None, *, subdivide=0)`: returns a configured `pyacvd.Clustering` for fine-grained control (plotting clusters, mixing fast/uniform, etc.).
- `cluster_ids(n_clusters, ...)`: per-point cluster ids without rebuilding the surface.
- `subdivide(nsub)`: linear subdivision returning a new `PolyData`.

### Backwards compatibility

The classic `pyacvd.Clustering` API is untouched and still works on every supported PyVista version (>= 0.37). Accessor registration is gated by a `hasattr(pv, "register_dataset_accessor")` check, so older PyVista installs are unaffected.

The accessor is also wired up via the `pyvista.accessors` entry point, so `mesh.acvd` works without an explicit `import pyacvd` once the package is installed.

### Notes

- Modeled after the [pyvista-manifold](https://github.com/pyvista/pyvista-manifold) accessor layout.
- README has a new "PyVista accessor (recommended)" section above the classic example.