### PR TITLE
Fix Sphinx roles in README that fail twine check (and gate it in PR CI)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -44,6 +44,9 @@ jobs:
     - name: Build sdist
       run: pipx run build --sdist
 
+    - name: Verify README renders on PyPI (twine check)
+      run: pipx run twine check --strict dist/*.tar.gz
+
     - name: Install sdist
       run: pip install dist/*.tar.gz
 

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ PyVista accessor (recommended, ``pyvista >= 0.48``)
 ===================================================
 
 Installing ``pyacvd`` registers an ``acvd`` namespace on every
-:class:`pyvista.PolyData`, so uniform remeshing slots straight into a
+``pyvista.PolyData``, so uniform remeshing slots straight into a
 PyVista pipeline. Once ``pyacvd`` is imported (or auto-discovered via
 PyVista's entry-point system) you can call ``mesh.acvd.<method>(...)``
 directly:
@@ -51,8 +51,8 @@ The accessor never mutates the source mesh and always returns a fresh
    one-shot uniform remesh.
 
 -  ``mesh.acvd.clustering(weights=None, subdivide=0)`` — return a
-   configured :class:`pyacvd.Clustering` for fine-grained control
-   (plotting clusters, mixing fast/uniform clustering, etc.).
+   configured ``pyacvd.Clustering`` for fine-grained control (plotting
+   clusters, mixing fast/uniform clustering, etc.).
 
 -  ``mesh.acvd.cluster_ids(n_clusters, ...)`` — per-point cluster id
    array, useful for visualization.

--- a/README.rst
+++ b/README.rst
@@ -28,10 +28,9 @@ PyVista accessor (recommended, ``pyvista >= 0.48``)
 ===================================================
 
 Installing ``pyacvd`` registers an ``acvd`` namespace on every
-``pyvista.PolyData``, so uniform remeshing slots straight into a
-PyVista pipeline. Once ``pyacvd`` is imported (or auto-discovered via
-PyVista's entry-point system) you can call ``mesh.acvd.<method>(...)``
-directly:
+``pyvista.PolyData``, so uniform remeshing slots straight into a PyVista
+pipeline. Once ``pyacvd`` is imported (or auto-discovered via PyVista's
+entry-point system) you can call ``mesh.acvd.<method>(...)`` directly:
 
 .. code:: python
 


### PR DESCRIPTION
The v0.4.0 release failed at the PyPI publish step because the README I added in #77 used Sphinx interpreted-text roles (`:class:\`pyvista.PolyData\``, `:class:\`pyacvd.Clustering\``) which `twine check` rejects. Failure: https://github.com/pyvista/pyacvd/actions/runs/25574339938/job/75079011573

PyPI's RST renderer is plain docutils and doesn't know about Sphinx roles, so the `long_description` fails markup validation and the upload aborts. My mistake.

### Fix

Replace the two `:class:\`...\`` references with plain `\`\`...\`\`` literals. The accessor docstrings still use proper Sphinx roles since they're rendered by the API docs build, not by PyPI.

### Prevent recurrence

Add `twine check --strict dist/*.tar.gz` to the `build_sdist` job in `.github/workflows/build-and-deploy.yml` so every PR exercises the same check the release job runs. `--strict` treats warnings as errors. The release path itself was already guarded; the gap was that PRs never built the sdist's metadata in a way that surfaced the failure before tagging.

### Verification

Built the sdist locally and ran `twine check --strict` against it: passes. After this PR merges, the v0.4.0 release will need to be retagged (e.g. v0.4.1) so the publish step runs against the corrected sdist.