### PR TITLE
Use pyvista's public API and int32 face indices

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,14 @@ testpaths = 'tests'
 line-length = 100
 
 [tool.ruff.lint]
-extend-select = ["I"]
+extend-select = ["I", "TID251"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+# pyvista is not always built on the stock ``vtkmodules`` wheel. An object from a
+# different binding is a different C++ type and VTK's setters reject it, so build
+# meshes through pyvista's public API instead.
+"vtk".msg = "Use pyvista's public API instead of importing VTK directly."
+"vtkmodules".msg = "Use pyvista's public API instead of importing VTK directly."
 
 [tool.scikit-build]
 # Setuptools-style build caching in a local directory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ classifiers = [
 ]
 dependencies = [
   "numpy",
-  "pyvista>=0.37.0",
+  # 0.42.0 adds PolyData.from_regular_faces and PolyData.regular_faces
+  "pyvista>=0.42.0",
   "pykdtree",
   # VTK < 9.5 doesn't have prebuilt ARM64 wheels
   "vtk~=9.5 ; sys_platform == 'linux' and platform_machine == 'aarch64'"

--- a/src/clustering.cpp
+++ b/src/clustering.cpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <stdexcept>
 #include <vector>
 
 #include <nanobind/nanobind.h>
@@ -74,7 +75,7 @@ template <typename T> inline void ArrayAddInplace(T *arr_a, const T *arr_b) noex
 
 template <typename T>
 NDArray<T, 2>
-PointNormals(NDArray<const T, 2> points_arr, NDArray<const int64_t, 2> faces_arr) {
+PointNormals(NDArray<const T, 2> points_arr, NDArray<const int32_t, 2> faces_arr) {
     int n_faces = faces_arr.shape(0);
     int n_points = points_arr.shape(0);
 
@@ -84,12 +85,13 @@ PointNormals(NDArray<const T, 2> points_arr, NDArray<const int64_t, 2> faces_arr
 
     T *fnorm = AllocateArray<T>(n_faces * 3);
     const T *v = points_arr.data();
-    const int64_t *f = faces_arr.data();
+    const int32_t *f = faces_arr.data();
 
     for (size_t i = 0; i < n_faces; i++) {
-        int64_t point0 = f[i * 3 + 0];
-        int64_t point1 = f[i * 3 + 1];
-        int64_t point2 = f[i * 3 + 2];
+        // Widen to size_t since a point index scaled by three exceeds int32
+        size_t point0 = f[i * 3 + 0];
+        size_t point1 = f[i * 3 + 1];
+        size_t point2 = f[i * 3 + 2];
 
         T v0_0 = v[point0 * 3 + 0];
         T v0_1 = v[point0 * 3 + 1];
@@ -131,9 +133,9 @@ PointNormals(NDArray<const T, 2> points_arr, NDArray<const int64_t, 2> faces_arr
 
     // Sum to pnorm in a single thread to avoid race condition
     for (size_t i = 0; i < n_faces; i++) {
-        int64_t point0 = f[i * 3 + 0];
-        int64_t point1 = f[i * 3 + 1];
-        int64_t point2 = f[i * 3 + 2];
+        size_t point0 = f[i * 3 + 0];
+        size_t point1 = f[i * 3 + 1];
+        size_t point2 = f[i * 3 + 2];
 
         pnorm[point0 * 3 + 0] += fnorm[i * 3 + 0];
         pnorm[point1 * 3 + 0] += fnorm[i * 3 + 0];
@@ -168,18 +170,19 @@ PointNormals(NDArray<const T, 2> points_arr, NDArray<const int64_t, 2> faces_arr
 
 template <typename T>
 NDArray<T, 2>
-FaceCentroid(const NDArray<const T, 2> points, const NDArray<const int64_t, 2> faces) {
+FaceCentroid(const NDArray<const T, 2> points, const NDArray<const int32_t, 2> faces) {
     const T *v = points.data();
-    const int64_t *f = faces.data();
+    const int32_t *f = faces.data();
 
     int n_faces = faces.shape(0);
     auto fmean_arr = MakeNDArray<T, 2>({n_faces, 3});
     T *fmean = fmean_arr.data();
 
     for (size_t i = 0; i < n_faces; i++) {
-        const int64_t point0 = f[i * 3 + 0];
-        const int64_t point1 = f[i * 3 + 1];
-        const int64_t point2 = f[i * 3 + 2];
+        // Widen to size_t since a point index scaled by three exceeds int32
+        const size_t point0 = f[i * 3 + 0];
+        const size_t point1 = f[i * 3 + 1];
+        const size_t point2 = f[i * 3 + 2];
 
         fmean[i * 3 + 0] =
             (v[point0 * 3 + 0] + v[point1 * 3 + 0] + v[point2 * 3 + 0]) * VAL_1_3;
@@ -194,7 +197,7 @@ FaceCentroid(const NDArray<const T, 2> points, const NDArray<const int64_t, 2> f
 
 template <typename T>
 NDArray<T, 2>
-FaceNormals(const NDArray<const T, 2> points, const NDArray<const int64_t, 2> faces) {
+FaceNormals(const NDArray<const T, 2> points, const NDArray<const int32_t, 2> faces) {
 
     int n_faces = faces.shape(0);
     int n_points = points.shape(0);
@@ -202,12 +205,13 @@ FaceNormals(const NDArray<const T, 2> points, const NDArray<const int64_t, 2> fa
     T *fnorm = fnorm_arr.data();
 
     const T *v = points.data();
-    const int64_t *f = faces.data();
+    const int32_t *f = faces.data();
 
     for (size_t i = 0; i < n_faces; i++) {
-        int64_t point0 = f[i * 3 + 0];
-        int64_t point1 = f[i * 3 + 1];
-        int64_t point2 = f[i * 3 + 2];
+        // Widen to size_t since a point index scaled by three exceeds int32
+        size_t point0 = f[i * 3 + 0];
+        size_t point1 = f[i * 3 + 1];
+        size_t point2 = f[i * 3 + 2];
 
         T v0_0 = v[point0 * 3 + 0];
         T v0_1 = v[point0 * 3 + 1];
@@ -255,7 +259,7 @@ nb::tuple RayTrace(
     NDArray<const T, 2> source_pt_arr,
     NDArray<const T, 2> source_n_arr,
     NDArray<const T, 2> v_arr,
-    NDArray<const int64_t, 2> f_arr,
+    NDArray<const int32_t, 2> f_arr,
     NDArray<const uint32_t, 2> idx_arr,
     const bool no_inf,                // true
     const int num_threads,            // -1
@@ -265,7 +269,7 @@ nb::tuple RayTrace(
     const T *source_pt = source_pt_arr.data();
     const T *source_n = source_n_arr.data();
     const T *v = v_arr.data();
-    const int64_t *f = f_arr.data();
+    const int32_t *f = f_arr.data();
     const uint32_t *idx = idx_arr.data();
 
     const size_t nfaces = f_arr.shape(0);
@@ -299,9 +303,10 @@ nb::tuple RayTrace(
 
             // Compute edges for this triangle. We do this here rather than
             // pre-computing all since we're exiting on the first intersection
-            int64_t i0 = f[ind * 3 + 0];
-            int64_t i1 = f[ind * 3 + 1];
-            int64_t i2 = f[ind * 3 + 2];
+            // Widen to size_t since a point index scaled by three exceeds int32
+            size_t i0 = f[ind * 3 + 0];
+            size_t i1 = f[ind * 3 + 1];
+            size_t i2 = f[ind * 3 + 2];
 
             T e1[3], e2[3];
             for (int k = 0; k < 3; k++) {
@@ -365,7 +370,7 @@ nb::tuple RayTrace(
     return nb::make_tuple(dists_arr, near_ind_arr);
 }
 
-nb::tuple NeighborsFromTriFaces(const int n_points, const NDArray<int64_t, 2> faces_arr) {
+nb::tuple NeighborsFromTriFaces(const int n_points, const NDArray<int32_t, 2> faces_arr) {
 
     // internal array: # of adjacent points per point
     int *n_nbr = AllocateArray<int>(n_points, true);
@@ -376,7 +381,7 @@ nb::tuple NeighborsFromTriFaces(const int n_points, const NDArray<int64_t, 2> fa
 
     // First, determine the total number of neighbors for each point
     for (size_t i = 0; i < n_faces; i++) {
-        int face_offset = i * 3;
+        size_t face_offset = i * 3;
 
         // Increment adjacency counts for each edge in the cell
         for (size_t j = 0; j < 3; j++) {
@@ -409,7 +414,7 @@ nb::tuple NeighborsFromTriFaces(const int n_points, const NDArray<int64_t, 2> fa
 
     // Determine the number of elements adjacent to each node
     for (size_t i = 0; i < n_faces; i++) {
-        int face_offset = i * 3;
+        size_t face_offset = i * 3;
 
         // Increment adjacency counts for each edge in the cell
         for (size_t j = 0; j < 3; j++) {
@@ -474,7 +479,7 @@ nb::tuple NeighborsFromTriFaces(const int n_points, const NDArray<int64_t, 2> fa
 template <typename T>
 nb::tuple PointWeights(
     NDArray<const T, 2> points_arr,
-    NDArray<const int64_t, 2> faces_arr,
+    NDArray<const int32_t, 2> faces_arr,
     NDArray<const T, 1> aweights_arr,
     int n_threads) {
 
@@ -494,14 +499,15 @@ nb::tuple PointWeights(
     T *wvertex = wvertex_arr.data();
 
     const T *v = points_arr.data();
-    const int64_t *f = faces_arr.data();
+    const int32_t *f = faces_arr.data();
 
     T *local_pweight = AllocateArray<T>(n_points, true);
 
     for (size_t i = 0; i < n_faces; i++) {
-        int64_t point0 = f[i * 3 + 0];
-        int64_t point1 = f[i * 3 + 1];
-        int64_t point2 = f[i * 3 + 2];
+        // Widen to size_t since a point index scaled by three exceeds int32
+        size_t point0 = f[i * 3 + 0];
+        size_t point1 = f[i * 3 + 1];
+        size_t point2 = f[i * 3 + 2];
 
         const T *v0 = v + point0 * 3, *v1 = v + point1 * 3, *v2 = v + point2 * 3;
 
@@ -1279,7 +1285,7 @@ nb::tuple Cluster(
     return nb::make_tuple(clusters_arr, n_disc > 0, n_clus_actual);
 }
 
-template <typename T> NDArray<T, 1> TriArea(NDArray<T, 2> points, NDArray<int64_t, 2> faces) {
+template <typename T> NDArray<T, 1> TriArea(NDArray<T, 2> points, NDArray<int32_t, 2> faces) {
 
     int n_faces = faces.shape(0);
     int n_points = points.shape(0);
@@ -1290,9 +1296,9 @@ template <typename T> NDArray<T, 1> TriArea(NDArray<T, 2> points, NDArray<int64_
     auto f = faces.view();
 
     for (size_t i = 0; i < n_faces; i++) {
-        int64_t point0 = f(i, 0);
-        int64_t point1 = f(i, 1);
-        int64_t point2 = f(i, 2);
+        int32_t point0 = f(i, 0);
+        int32_t point1 = f(i, 1);
+        int32_t point2 = f(i, 2);
 
         T v0_0 = v(point0, 0);
         T v0_1 = v(point0, 1);
@@ -1326,7 +1332,7 @@ template <typename T> NDArray<T, 1> TriArea(NDArray<T, 2> points, NDArray<int64_
 
 template <typename T>
 nb::tuple SubdivideTriangles(
-    const NDArray<T, 2> points, const NDArray<int64_t, 2> faces, const double tgtlen) {
+    const NDArray<T, 2> points, const NDArray<int32_t, 2> faces, const double tgtlen) {
 
     const int nvert = points.shape(0);
     const int nface = faces.shape(0);
@@ -1346,47 +1352,59 @@ nb::tuple SubdivideTriangles(
 
     const T *v_data = points.data();
 
+    // Face indices are int32, so the subdivided mesh must stay addressable by one
+    const int64_t max_points = static_cast<int64_t>(nvert) + nface_new;
+    if (max_points > std::numeric_limits<int32_t>::max()) {
+        throw std::overflow_error(
+            "Subdivided mesh exceeds the maximum number of points addressable by an "
+            "int32 face index.");
+    }
+
     // Size Vertex and face arrays for maximum possible array sizes
-    T *newv = new T[(nvert + nface_new) * 3];
-    int64_t *newf = new int64_t[nface_new * 3];
+    T *newv = new T[static_cast<size_t>(max_points) * 3];
+    int32_t *newf = new int32_t[static_cast<size_t>(nface_new) * 3];
 
     // copy existing vertex array
-    std::copy(v_data, v_data + nvert * 3, newv);
+    std::copy(v_data, v_data + static_cast<size_t>(nvert) * 3, newv);
 
-    // split triangles into three new ones
+    // split triangles into three new ones. Counters are size_t so the offsets
+    // into the new arrays are computed in 64 bit
     int nsub = 0;
-    int fc = 0;
-    int vc = nvert;
+    size_t fc = 0;
+    size_t vc = nvert;
     for (size_t i = 0; i < nface; i++) {
-        const int point0 = f(i, 0);
-        const int point1 = f(i, 1);
-        const int point2 = f(i, 2);
+        const int32_t point0 = f(i, 0);
+        const int32_t point1 = f(i, 1);
+        const int32_t point2 = f(i, 2);
 
         // Split if triangle length exceeds target area
         if (tarea(i) > tgtlen) {
 
+            // Index of the first new point. Guarded above to fit an int32
+            const int32_t new_point = static_cast<int32_t>(vc);
+
             // Face 0
             newf[fc * 3 + 0] = point0;
-            newf[fc * 3 + 1] = vc;
-            newf[fc * 3 + 2] = vc + 2;
+            newf[fc * 3 + 1] = new_point;
+            newf[fc * 3 + 2] = new_point + 2;
             fc += 1;
 
             // Face 1
             newf[fc * 3 + 0] = point1;
-            newf[fc * 3 + 1] = vc + 1;
-            newf[fc * 3 + 2] = vc;
+            newf[fc * 3 + 1] = new_point + 1;
+            newf[fc * 3 + 2] = new_point;
             fc += 1;
 
             // Face 2
             newf[fc * 3 + 0] = point2;
-            newf[fc * 3 + 1] = vc + 2;
-            newf[fc * 3 + 2] = vc + 1;
+            newf[fc * 3 + 1] = new_point + 2;
+            newf[fc * 3 + 2] = new_point + 1;
             fc += 1;
 
             // Face 3
-            newf[fc * 3 + 0] = vc;
-            newf[fc * 3 + 1] = vc + 1;
-            newf[fc * 3 + 2] = vc + 2;
+            newf[fc * 3 + 0] = new_point;
+            newf[fc * 3 + 1] = new_point + 1;
+            newf[fc * 3 + 2] = new_point + 2;
             fc += 1;
 
             // New Vertices
@@ -1415,8 +1433,8 @@ nb::tuple SubdivideTriangles(
         }
     }
 
-    auto newv_arr = WrapNDarray<T, 2>(newv, {vc, 3});
-    auto newf_arr = WrapNDarray<int64_t, 2>(newf, {fc, 3});
+    auto newv_arr = WrapNDarray<T, 2>(newv, {static_cast<int>(vc), 3});
+    auto newf_arr = WrapNDarray<int32_t, 2>(newf, {static_cast<int>(fc), 3});
     return nb::make_tuple(newv_arr, newf_arr, nsub);
 }
 

--- a/src/clustering.cpp
+++ b/src/clustering.cpp
@@ -83,15 +83,14 @@ PointNormals(NDArray<const T, 2> points_arr, NDArray<const int32_t, 2> faces_arr
     auto pnorm_arr = MakeNDArray<T, 2>({n_points, 3}, true);
     T *pnorm = pnorm_arr.data();
 
-    T *fnorm = AllocateArray<T>(n_faces * 3);
+    T *fnorm = AllocateArray<T>(static_cast<size_t>(n_faces) * 3);
     const T *v = points_arr.data();
     const int32_t *f = faces_arr.data();
 
     for (size_t i = 0; i < n_faces; i++) {
-        // Widen to size_t since a point index scaled by three exceeds int32
-        size_t point0 = f[i * 3 + 0];
-        size_t point1 = f[i * 3 + 1];
-        size_t point2 = f[i * 3 + 2];
+        int64_t point0 = f[i * 3 + 0];
+        int64_t point1 = f[i * 3 + 1];
+        int64_t point2 = f[i * 3 + 2];
 
         T v0_0 = v[point0 * 3 + 0];
         T v0_1 = v[point0 * 3 + 1];
@@ -133,9 +132,9 @@ PointNormals(NDArray<const T, 2> points_arr, NDArray<const int32_t, 2> faces_arr
 
     // Sum to pnorm in a single thread to avoid race condition
     for (size_t i = 0; i < n_faces; i++) {
-        size_t point0 = f[i * 3 + 0];
-        size_t point1 = f[i * 3 + 1];
-        size_t point2 = f[i * 3 + 2];
+        int64_t point0 = f[i * 3 + 0];
+        int64_t point1 = f[i * 3 + 1];
+        int64_t point2 = f[i * 3 + 2];
 
         pnorm[point0 * 3 + 0] += fnorm[i * 3 + 0];
         pnorm[point1 * 3 + 0] += fnorm[i * 3 + 0];
@@ -179,10 +178,9 @@ FaceCentroid(const NDArray<const T, 2> points, const NDArray<const int32_t, 2> f
     T *fmean = fmean_arr.data();
 
     for (size_t i = 0; i < n_faces; i++) {
-        // Widen to size_t since a point index scaled by three exceeds int32
-        const size_t point0 = f[i * 3 + 0];
-        const size_t point1 = f[i * 3 + 1];
-        const size_t point2 = f[i * 3 + 2];
+        const int64_t point0 = f[i * 3 + 0];
+        const int64_t point1 = f[i * 3 + 1];
+        const int64_t point2 = f[i * 3 + 2];
 
         fmean[i * 3 + 0] =
             (v[point0 * 3 + 0] + v[point1 * 3 + 0] + v[point2 * 3 + 0]) * VAL_1_3;
@@ -208,10 +206,9 @@ FaceNormals(const NDArray<const T, 2> points, const NDArray<const int32_t, 2> fa
     const int32_t *f = faces.data();
 
     for (size_t i = 0; i < n_faces; i++) {
-        // Widen to size_t since a point index scaled by three exceeds int32
-        size_t point0 = f[i * 3 + 0];
-        size_t point1 = f[i * 3 + 1];
-        size_t point2 = f[i * 3 + 2];
+        int64_t point0 = f[i * 3 + 0];
+        int64_t point1 = f[i * 3 + 1];
+        int64_t point2 = f[i * 3 + 2];
 
         T v0_0 = v[point0 * 3 + 0];
         T v0_1 = v[point0 * 3 + 1];
@@ -303,10 +300,12 @@ nb::tuple RayTrace(
 
             // Compute edges for this triangle. We do this here rather than
             // pre-computing all since we're exiting on the first intersection
-            // Widen to size_t since a point index scaled by three exceeds int32
-            size_t i0 = f[ind * 3 + 0];
-            size_t i1 = f[ind * 3 + 1];
-            size_t i2 = f[ind * 3 + 2];
+            //
+            // ind is a uint32, so scale it in size_t to avoid wrapping
+            const size_t find = static_cast<size_t>(ind) * 3;
+            int64_t i0 = f[find + 0];
+            int64_t i1 = f[find + 1];
+            int64_t i2 = f[find + 2];
 
             T e1[3], e2[3];
             for (int k = 0; k < 3; k++) {
@@ -504,10 +503,9 @@ nb::tuple PointWeights(
     T *local_pweight = AllocateArray<T>(n_points, true);
 
     for (size_t i = 0; i < n_faces; i++) {
-        // Widen to size_t since a point index scaled by three exceeds int32
-        size_t point0 = f[i * 3 + 0];
-        size_t point1 = f[i * 3 + 1];
-        size_t point2 = f[i * 3 + 2];
+        int64_t point0 = f[i * 3 + 0];
+        int64_t point1 = f[i * 3 + 1];
+        int64_t point2 = f[i * 3 + 2];
 
         const T *v0 = v + point0 * 3, *v1 = v + point1 * 3, *v2 = v + point2 * 3;
 
@@ -1296,9 +1294,9 @@ template <typename T> NDArray<T, 1> TriArea(NDArray<T, 2> points, NDArray<int32_
     auto f = faces.view();
 
     for (size_t i = 0; i < n_faces; i++) {
-        int32_t point0 = f(i, 0);
-        int32_t point1 = f(i, 1);
-        int32_t point2 = f(i, 2);
+        int64_t point0 = f(i, 0);
+        int64_t point1 = f(i, 1);
+        int64_t point2 = f(i, 2);
 
         T v0_0 = v(point0, 0);
         T v0_1 = v(point0, 1);
@@ -1334,8 +1332,10 @@ template <typename T>
 nb::tuple SubdivideTriangles(
     const NDArray<T, 2> points, const NDArray<int32_t, 2> faces, const double tgtlen) {
 
-    const int nvert = points.shape(0);
-    const int nface = faces.shape(0);
+    // 64 bit throughout so that neither the count of new faces nor the bound
+    // checked below can overflow before it is tested
+    const int64_t nvert = points.shape(0);
+    const int64_t nface = faces.shape(0);
     auto f = faces.view();
     auto v = points.view();
 
@@ -1343,8 +1343,8 @@ nb::tuple SubdivideTriangles(
     const auto tarea = TriArea(points, faces);
 
     // determine the total number of new faces
-    int nface_new = nface;
-    for (size_t i = 0; i < nface; i++) {
+    int64_t nface_new = nface;
+    for (int64_t i = 0; i < nface; i++) {
         if (tarea(i) > tgtlen) {
             nface_new += 3;
         }
@@ -1353,7 +1353,7 @@ nb::tuple SubdivideTriangles(
     const T *v_data = points.data();
 
     // Face indices are int32, so the subdivided mesh must stay addressable by one
-    const int64_t max_points = static_cast<int64_t>(nvert) + nface_new;
+    const int64_t max_points = nvert + nface_new;
     if (max_points > std::numeric_limits<int32_t>::max()) {
         throw std::overflow_error(
             "Subdivided mesh exceeds the maximum number of points addressable by an "
@@ -1367,15 +1367,14 @@ nb::tuple SubdivideTriangles(
     // copy existing vertex array
     std::copy(v_data, v_data + static_cast<size_t>(nvert) * 3, newv);
 
-    // split triangles into three new ones. Counters are size_t so the offsets
-    // into the new arrays are computed in 64 bit
+    // split triangles into three new ones
     int nsub = 0;
-    size_t fc = 0;
-    size_t vc = nvert;
-    for (size_t i = 0; i < nface; i++) {
-        const int32_t point0 = f(i, 0);
-        const int32_t point1 = f(i, 1);
-        const int32_t point2 = f(i, 2);
+    int64_t fc = 0;
+    int64_t vc = nvert;
+    for (int64_t i = 0; i < nface; i++) {
+        const int64_t point0 = f(i, 0);
+        const int64_t point1 = f(i, 1);
+        const int64_t point2 = f(i, 2);
 
         // Split if triangle length exceeds target area
         if (tarea(i) > tgtlen) {
@@ -1384,19 +1383,19 @@ nb::tuple SubdivideTriangles(
             const int32_t new_point = static_cast<int32_t>(vc);
 
             // Face 0
-            newf[fc * 3 + 0] = point0;
+            newf[fc * 3 + 0] = static_cast<int32_t>(point0);
             newf[fc * 3 + 1] = new_point;
             newf[fc * 3 + 2] = new_point + 2;
             fc += 1;
 
             // Face 1
-            newf[fc * 3 + 0] = point1;
+            newf[fc * 3 + 0] = static_cast<int32_t>(point1);
             newf[fc * 3 + 1] = new_point + 1;
             newf[fc * 3 + 2] = new_point;
             fc += 1;
 
             // Face 2
-            newf[fc * 3 + 0] = point2;
+            newf[fc * 3 + 0] = static_cast<int32_t>(point2);
             newf[fc * 3 + 1] = new_point + 2;
             newf[fc * 3 + 2] = new_point + 1;
             fc += 1;
@@ -1426,9 +1425,9 @@ nb::tuple SubdivideTriangles(
             nsub += 1;
 
         } else {
-            newf[fc * 3 + 0] = point0;
-            newf[fc * 3 + 1] = point1;
-            newf[fc * 3 + 2] = point2;
+            newf[fc * 3 + 0] = static_cast<int32_t>(point0);
+            newf[fc * 3 + 1] = static_cast<int32_t>(point1);
+            newf[fc * 3 + 2] = static_cast<int32_t>(point2);
             fc += 1;
         }
     }

--- a/src/pyacvd/__init__.py
+++ b/src/pyacvd/__init__.py
@@ -10,7 +10,7 @@ except PackageNotFoundError:
 
 # Register the ``acvd`` PyVista accessor on pyvista >= 0.48. The
 # classic ``Clustering`` API works on every supported pyvista version
-# (>= 0.37); the accessor is a thin convenience layer on top and is
+# (>= 0.42); the accessor is a thin convenience layer on top and is
 # silently skipped on older releases.
 import pyvista as _pv
 

--- a/src/pyacvd/_clustering.pyi
+++ b/src/pyacvd/_clustering.pyi
@@ -10,7 +10,6 @@ NDArray_FLOAT64 = NDArray[np.float64]
 NDArray_FLOAT32_64 = Union[NDArray_FLOAT32, NDArray_FLOAT64]
 
 T = TypeVar("T", np.float32, np.float64)
-U = TypeVar("U", np.int32, np.int64)
 
 def cluster(
     neigh_arr: NDArray_INT32,
@@ -37,19 +36,19 @@ def unique_edges(
 ) -> NDArray_INT32: ...
 def face_normals(
     points: NDArray[T],
-    faces: NDArray[U],
+    faces: NDArray_INT32,
 ) -> NDArray[T]: ...
 def point_normals(
     points: NDArray[T],
-    faces: NDArray[U],
+    faces: NDArray_INT32,
 ) -> NDArray[T]: ...
 def face_centroid(
     points: NDArray[T],
-    faces: NDArray[U],
+    faces: NDArray_INT32,
 ) -> NDArray[T]: ...
 def weighted_points(
     points: NDArray[T],
-    faces: NDArray[U],
+    faces: NDArray_INT32,
     aweights: NDArray[T],
     n_threads: int,
 ) -> Tuple[NDArray[T], NDArray[T]]: ...
@@ -57,7 +56,7 @@ def ray_trace(
     source_pt: NDArray[T],
     source_n: NDArray[T],
     target_v: NDArray[T],
-    target_f: NDArray[U],
+    target_f: NDArray_INT32,
     idx: NDArray_UINT32,
     no_inf: bool,
     num_threads: int,
@@ -66,10 +65,10 @@ def ray_trace(
 ) -> NDArray[T]: ...
 def neighbors_from_trimesh(
     n_points: int,
-    faces: NDArray[U],
+    faces: NDArray_INT32,
 ) -> Tuple[NDArray_INT32, NDArray_INT32]: ...
 def subdivision(
     points: NDArray[T],
-    faces: NDArray[U],
+    faces: NDArray_INT32,
     tgtlen: float,
-) -> Tuple[NDArray_FLOAT64, NDArray[U], int]: ...
+) -> Tuple[NDArray_FLOAT64, NDArray_INT32, int]: ...

--- a/src/pyacvd/clustering.py
+++ b/src/pyacvd/clustering.py
@@ -71,7 +71,10 @@ def point_normals(mesh: PolyData) -> NDArray[T]:
 
 def _tri_faces_from_poly(mesh: PolyData) -> NDArray[U]:
     """Return the triangle faces from a polydata."""
-    return cast(NDArray[U], mesh.regular_faces)
+    faces = mesh.regular_faces
+    if faces.shape[1] != 3:
+        raise ValueError("Input mesh must be composed of all triangles.")
+    return cast(NDArray[U], faces)
 
 
 def unique_edges(neigh: NDArray_INT32, neigh_off: NDArray_INT32) -> NDArray_INT32:
@@ -611,7 +614,7 @@ def create_mesh(
     clusters, comparing with the normals of each face, and reversing the order
     if required.  Finally, it creates a new surface using vtk and returns it.
     """
-    faces = mesh.regular_faces
+    faces = _tri_faces_from_poly(mesh)
     points = mesh.points.astype(np.float64, copy=False)
 
     # Compute centroids

--- a/src/pyacvd/clustering.py
+++ b/src/pyacvd/clustering.py
@@ -77,7 +77,8 @@ def _tri_faces_from_poly(mesh: PolyData) -> NDArray_INT32:
 
     VTK stores the connectivity using its own id type, which is usually int64.
     The C extension indexes points with int32, so the faces are narrowed here
-    and the point count is checked to ensure the indices cannot wrap.
+    and the point count is checked to ensure the indices cannot wrap. Only
+    triangles have a ``(n, 3)`` connectivity, so anything else is rejected.
     """
     if mesh.n_points > MAX_POINTS:
         raise ValueError(
@@ -85,10 +86,15 @@ def _tri_faces_from_poly(mesh: PolyData) -> NDArray_INT32:
             f"{MAX_POINTS} points addressable by an int32 face index."
         )
 
-    faces = mesh.regular_faces
-    if faces.shape[1] != 3:
-        raise ValueError("Input mesh must be composed of all triangles.")
-    return cast(NDArray_INT32, faces.astype(np.int32, copy=False))
+    if mesh.n_cells == 0:
+        return np.empty((0, 3), dtype=np.int32)
+
+    if not mesh.is_all_triangles:
+        raise ValueError(
+            "Input mesh must be composed of all triangles. Hint: `mesh.triangulate` first."
+        )
+
+    return cast(NDArray_INT32, mesh.regular_faces.astype(np.int32, copy=False))
 
 
 def unique_edges(neigh: NDArray_INT32, neigh_off: NDArray_INT32) -> NDArray_INT32:
@@ -434,8 +440,7 @@ def polydata_from_faces(points: NDArray_FLOAT32_64, faces: NDArray_INT32_64) -> 
 
     # Uses pyvista's public constructor rather than building a vtkCellArray here so
     # this works with any VTK binding pyvista is built on. It also stores the cells
-    # without an offsets array where the VTK build supports fixed size storage, and
-    # preserves an int32 faces array instead of widening it to the VTK id type.
+    # without an offsets array where the VTK build supports fixed size storage.
     return PolyData.from_regular_faces(points, faces, deep=True)
 
 

--- a/src/pyacvd/clustering.py
+++ b/src/pyacvd/clustering.py
@@ -26,12 +26,15 @@ NDArray_FLOAT64 = NDArray[np.float64]
 NDArray_FLOAT32_64 = Union[NDArray_FLOAT32, NDArray_FLOAT64]
 NDArray_UINT32 = npt.NDArray[np.uint32]
 
-U = TypeVar("U", np.int32, np.int64)
 T = TypeVar("T", np.float32, np.float64)
 
 LOG = logging.getLogger(__name__)
 
 MAX_THREADS = 4
+
+# Face indices are int32 through the C extension, so a mesh cannot have more
+# points than an int32 can address
+MAX_POINTS = int(np.iinfo(np.int32).max)
 
 
 def point_normals(mesh: PolyData) -> NDArray[T]:
@@ -69,12 +72,23 @@ def point_normals(mesh: PolyData) -> NDArray[T]:
     return _clustering.point_normals(mesh.points, _tri_faces_from_poly(mesh))
 
 
-def _tri_faces_from_poly(mesh: PolyData) -> NDArray[U]:
-    """Return the triangle faces from a polydata."""
+def _tri_faces_from_poly(mesh: PolyData) -> NDArray_INT32:
+    """Return the triangle faces from a polydata as int32.
+
+    VTK stores the connectivity using its own id type, which is usually int64.
+    The C extension indexes points with int32, so the faces are narrowed here
+    and the point count is checked to ensure the indices cannot wrap.
+    """
+    if mesh.n_points > MAX_POINTS:
+        raise ValueError(
+            f"Mesh has {mesh.n_points} points, which exceeds the maximum of "
+            f"{MAX_POINTS} points addressable by an int32 face index."
+        )
+
     faces = mesh.regular_faces
     if faces.shape[1] != 3:
         raise ValueError("Input mesh must be composed of all triangles.")
-    return cast(NDArray[U], faces)
+    return cast(NDArray_INT32, faces.astype(np.int32, copy=False))
 
 
 def unique_edges(neigh: NDArray_INT32, neigh_off: NDArray_INT32) -> NDArray_INT32:
@@ -425,7 +439,7 @@ def polydata_from_faces(points: NDArray_FLOAT32_64, faces: NDArray_INT32_64) -> 
     return PolyData.from_regular_faces(points, faces, deep=True)
 
 
-def face_centroid_arrays(points: NDArray[T], faces: NDArray[U]) -> NDArray[T]:
+def face_centroid_arrays(points: NDArray[T], faces: NDArray_INT32) -> NDArray[T]:
     """
     Return the centroid of each face of a triangular mesh.
 
@@ -514,7 +528,7 @@ def ray_trace(
     source_v: NDArray[T],
     source_n: NDArray[T],
     target_v: NDArray[T],
-    target_f: NDArray[U],
+    target_f: NDArray_INT32,
     neigh: NDArray_UINT32,
     no_inf: bool = True,
     num_threads: int = 8,
@@ -547,7 +561,7 @@ def _unique_row_indices(a: Matrix) -> NDArray_INT32_64:
     return idx
 
 
-def face_normals_array(points: NDArray[T], faces: NDArray[U]) -> NDArray[T]:
+def face_normals_array(points: NDArray[T], faces: NDArray_INT32) -> NDArray[T]:
     """
     Return the normals of faces in a mesh or a set of vertices and faces.
 
@@ -686,9 +700,7 @@ def _cluster_centroid(
 
 def _subdivide(mesh: PolyData, nsub: int) -> PolyData:
     """Perform a linear subdivision of a mesh"""
-    new_faces = mesh.faces.reshape(-1, 4)[:, 1:]
-    if new_faces.dtype != np.int32:
-        new_faces = new_faces.astype(np.int32)
+    new_faces = _tri_faces_from_poly(mesh)
 
     new_points = mesh.points
     if new_points.dtype != np.double:

--- a/src/pyacvd/clustering.py
+++ b/src/pyacvd/clustering.py
@@ -8,9 +8,7 @@ import numpy.typing as npt
 import pyvista as pv
 from numpy.typing import NDArray
 from pykdtree.kdtree import KDTree
-from pyvista import ID_TYPE
 from pyvista.core.pointset import PolyData
-from vtkmodules.vtkCommonDataModel import vtkCellArray
 
 from pyacvd import _clustering
 
@@ -73,7 +71,7 @@ def point_normals(mesh: PolyData) -> NDArray[T]:
 
 def _tri_faces_from_poly(mesh: PolyData) -> NDArray[U]:
     """Return the triangle faces from a polydata."""
-    return cast(NDArray[U], mesh._connectivity_array.reshape(-1, 3))
+    return cast(NDArray[U], mesh.regular_faces)
 
 
 def unique_edges(neigh: NDArray_INT32, neigh_off: NDArray_INT32) -> NDArray_INT32:
@@ -417,14 +415,11 @@ def polydata_from_faces(points: NDArray_FLOAT32_64, faces: NDArray_INT32_64) -> 
     if faces.ndim != 2:
         raise ValueError("Expected a two dimensional face array.")
 
-    pdata = PolyData()
-    pdata.points = points
-
-    carr = vtkCellArray()
-    offset = np.arange(0, faces.size + 1, faces.shape[1], dtype=ID_TYPE)
-    carr.SetData(pv.numpy_to_idarr(offset, deep=True), pv.numpy_to_idarr(faces, deep=True))
-    pdata.SetPolys(carr)
-    return pdata
+    # Uses pyvista's public constructor rather than building a vtkCellArray here so
+    # this works with any VTK binding pyvista is built on. It also stores the cells
+    # without an offsets array where the VTK build supports fixed size storage, and
+    # preserves an int32 faces array instead of widening it to the VTK id type.
+    return PolyData.from_regular_faces(points, faces, deep=True)
 
 
 def face_centroid_arrays(points: NDArray[T], faces: NDArray[U]) -> NDArray[T]:
@@ -616,7 +611,7 @@ def create_mesh(
     clusters, comparing with the normals of each face, and reversing the order
     if required.  Finally, it creates a new surface using vtk and returns it.
     """
-    faces = mesh._connectivity_array.reshape(-1, 3)
+    faces = mesh.regular_faces
     points = mesh.points.astype(np.float64, copy=False)
 
     # Compute centroids

--- a/src/pyacvd/clustering.py
+++ b/src/pyacvd/clustering.py
@@ -441,7 +441,11 @@ def polydata_from_faces(points: NDArray_FLOAT32_64, faces: NDArray_INT32_64) -> 
     # Uses pyvista's public constructor rather than building a vtkCellArray here so
     # this works with any VTK binding pyvista is built on. It also stores the cells
     # without an offsets array where the VTK build supports fixed size storage.
-    return PolyData.from_regular_faces(points, faces, deep=True)
+    #
+    # Shallow by default, matching pyvista. VTK holds a reference to the buffers, so
+    # they outlive the caller's arrays; the mesh does alias them, and callers that
+    # reuse an array after passing it here should hand over a copy.
+    return PolyData.from_regular_faces(points, faces)
 
 
 def face_centroid_arrays(points: NDArray[T], faces: NDArray_INT32) -> NDArray[T]:

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -135,3 +135,9 @@ def test_polydata_from_faces_fixed_size_storage() -> None:
     mesh = clustering.polydata_from_faces(points, faces)
 
     assert mesh.GetPolys().IsStorageFixedSize()
+
+
+def test_point_normals_non_triangular() -> None:
+    """A non-triangular mesh must be rejected rather than silently misread."""
+    with pytest.raises(ValueError, match="all triangles"):
+        clustering.point_normals(pv.Plane(i_resolution=2, j_resolution=2))

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -1,11 +1,25 @@
+import ast
 import os
+from pathlib import Path
+
+import numpy as np
 import pyacvd
 import pytest
 import pyvista as pv
+from pyacvd import clustering
 from pyvista import examples
 from pyvista.plotting import system_supports_plotting
 
 NO_PLOTTING = not system_supports_plotting()
+
+try:
+    # pyvista 0.49 rewrote ``CellArray.from_regular_cells`` to use VTK's fixed
+    # size cell storage and to stop widening an int32 connectivity array to the
+    # VTK id type. This constant was added by that change, so its absence means
+    # the installed pyvista still writes an explicit offsets array and upcasts.
+    from pyvista.core._vtk_utilities import _SUPPORTS_FIXED_SIZE_STORAGE
+except ImportError:
+    _SUPPORTS_FIXED_SIZE_STORAGE = False
 
 # skip plotting on windows. This occurs specifically on Python 3.13, skipping
 # all for the time being
@@ -61,3 +75,63 @@ def test_cow() -> None:
     clus.plot(off_screen=True)
     remesh = clus.create_mesh()
     assert remesh.n_points
+
+
+def test_no_direct_vtk_import() -> None:
+    """Meshes must be built through pyvista rather than a VTK binding.
+
+    pyvista is not always built on the stock ``vtkmodules`` wheel. A
+    ``vtkCellArray`` from a different binding is a different C++ type and
+    ``vtkPolyData.SetPolys`` rejects it.
+    """
+    tree = ast.parse(Path(clustering.__file__).read_text())
+
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            roots.add(node.module.split(".")[0])
+
+    assert "vtkmodules" not in roots
+    assert "vtk" not in roots
+
+
+def test_polydata_from_faces() -> None:
+    points = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]])
+    faces = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int64)
+
+    mesh = clustering.polydata_from_faces(points, faces)
+
+    assert mesh.n_points == 4
+    assert mesh.n_cells == 2
+    assert np.array_equal(mesh.regular_faces, faces)
+
+
+def test_polydata_from_faces_invalid() -> None:
+    points = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0]])
+    with pytest.raises(ValueError, match="two dimensional"):
+        clustering.polydata_from_faces(points, np.array([0, 1, 2], dtype=np.int64))
+
+
+@pytest.mark.skipif(not _SUPPORTS_FIXED_SIZE_STORAGE, reason="Requires fixed size cell storage")
+def test_polydata_from_faces_int32() -> None:
+    """An int32 faces array must not be widened to the VTK id type."""
+    points = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]])
+    faces = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int32)
+
+    mesh = clustering.polydata_from_faces(points, faces)
+
+    assert mesh.regular_faces.dtype == np.int32
+    assert np.array_equal(mesh.regular_faces, faces)
+
+
+@pytest.mark.skipif(not _SUPPORTS_FIXED_SIZE_STORAGE, reason="Requires fixed size cell storage")
+def test_polydata_from_faces_fixed_size_storage() -> None:
+    """Triangles are stored without an explicit offsets array."""
+    points = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]])
+    faces = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int64)
+
+    mesh = clustering.polydata_from_faces(points, faces)
+
+    assert mesh.GetPolys().IsStorageFixedSize()

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -6,7 +6,7 @@ import numpy as np
 import pyacvd
 import pytest
 import pyvista as pv
-from pyacvd import clustering
+from pyacvd import _clustering, clustering
 from pyvista import examples
 from pyvista.plotting import system_supports_plotting
 
@@ -141,3 +141,43 @@ def test_point_normals_non_triangular() -> None:
     """A non-triangular mesh must be rejected rather than silently misread."""
     with pytest.raises(ValueError, match="all triangles"):
         clustering.point_normals(pv.Plane(i_resolution=2, j_resolution=2))
+
+
+def test_faces_are_int32() -> None:
+    """Faces stay int32 through a full clustering round trip."""
+    clus = pyacvd.Clustering(pv.Sphere().triangulate())
+    assert clustering._tri_faces_from_poly(clus.mesh).dtype == np.int32
+
+    clus.subdivide(2)
+    sub_faces = clustering._tri_faces_from_poly(clus.mesh)
+    assert sub_faces.dtype == np.int32
+    assert np.array_equal(sub_faces, clus.mesh.regular_faces)
+
+    clus.cluster(500)
+    remesh = clus.create_mesh()
+    assert remesh.n_points == 500
+    assert clustering._tri_faces_from_poly(remesh).dtype == np.int32
+
+
+def test_subdivision_returns_int32() -> None:
+    """The subdivision extension returns an int32 faces array."""
+    mesh = pv.Sphere().triangulate()
+    points = mesh.points.astype(np.float64)
+    faces = clustering._tri_faces_from_poly(mesh)
+
+    new_points, new_faces, nsub = _clustering.subdivision(points, faces, 0.0)
+
+    assert new_faces.dtype == np.int32
+    assert nsub == faces.shape[0]
+    assert new_faces.shape == (faces.shape[0] * 4, 3)
+    assert new_faces.max() == new_points.shape[0] - 1
+
+
+def test_tri_faces_from_poly_too_many_points(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A mesh larger than an int32 face index can address must be rejected."""
+    mesh = pv.Sphere().triangulate()
+    n_points = clustering.MAX_POINTS + 1
+    monkeypatch.setattr(type(mesh), "n_points", property(lambda self: n_points))
+
+    with pytest.raises(ValueError, match=f"{n_points} points, which exceeds"):
+        clustering._tri_faces_from_poly(mesh)

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -18,6 +18,9 @@ def _supports_fixed_size_storage() -> bool:
     cell storage, which drops the explicit offsets array and stops widening an
     int32 connectivity array to the VTK id type. This probes that behaviour rather
     than a private symbol, which can be renamed without deprecation.
+
+    Delete this and the two skips it gates once ``pyvista>=0.49`` is the floor in
+    ``pyproject.toml``; the behaviour is unconditional from that release on.
     """
     points = np.zeros((3, 3))
     faces = np.array([[0, 1, 2]], dtype=np.int32)

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -1,6 +1,4 @@
-import ast
 import os
-from pathlib import Path
 
 import numpy as np
 import pyacvd
@@ -12,14 +10,21 @@ from pyvista.plotting import system_supports_plotting
 
 NO_PLOTTING = not system_supports_plotting()
 
-try:
-    # pyvista 0.49 rewrote ``CellArray.from_regular_cells`` to use VTK's fixed
-    # size cell storage and to stop widening an int32 connectivity array to the
-    # VTK id type. This constant was added by that change, so its absence means
-    # the installed pyvista still writes an explicit offsets array and upcasts.
-    from pyvista.core._vtk_utilities import _SUPPORTS_FIXED_SIZE_STORAGE
-except ImportError:
-    _SUPPORTS_FIXED_SIZE_STORAGE = False
+
+def _supports_fixed_size_storage() -> bool:
+    """Return True when pyvista stores regular cells with fixed size storage.
+
+    pyvista 0.49 rewrote ``CellArray.from_regular_cells`` to use VTK's fixed size
+    cell storage, which drops the explicit offsets array and stops widening an
+    int32 connectivity array to the VTK id type. This probes that behaviour rather
+    than a private symbol, which can be renamed without deprecation.
+    """
+    points = np.zeros((3, 3))
+    faces = np.array([[0, 1, 2]], dtype=np.int32)
+    return bool(pv.PolyData.from_regular_faces(points, faces).regular_faces.dtype == np.int32)
+
+
+SUPPORTS_FIXED_SIZE_STORAGE = _supports_fixed_size_storage()
 
 # skip plotting on windows. This occurs specifically on Python 3.13, skipping
 # all for the time being
@@ -77,26 +82,6 @@ def test_cow() -> None:
     assert remesh.n_points
 
 
-def test_no_direct_vtk_import() -> None:
-    """Meshes must be built through pyvista rather than a VTK binding.
-
-    pyvista is not always built on the stock ``vtkmodules`` wheel. A
-    ``vtkCellArray`` from a different binding is a different C++ type and
-    ``vtkPolyData.SetPolys`` rejects it.
-    """
-    tree = ast.parse(Path(clustering.__file__).read_text())
-
-    roots: set[str] = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            roots.update(alias.name.split(".")[0] for alias in node.names)
-        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
-            roots.add(node.module.split(".")[0])
-
-    assert "vtkmodules" not in roots
-    assert "vtk" not in roots
-
-
 def test_polydata_from_faces() -> None:
     points = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]])
     faces = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int64)
@@ -114,9 +99,13 @@ def test_polydata_from_faces_invalid() -> None:
         clustering.polydata_from_faces(points, np.array([0, 1, 2], dtype=np.int64))
 
 
-@pytest.mark.skipif(not _SUPPORTS_FIXED_SIZE_STORAGE, reason="Requires fixed size cell storage")
+@pytest.mark.skipif(not SUPPORTS_FIXED_SIZE_STORAGE, reason="Requires fixed size cell storage")
 def test_polydata_from_faces_int32() -> None:
-    """An int32 faces array must not be widened to the VTK id type."""
+    """An int32 faces array must not be widened to the VTK id type.
+
+    The probe above uses a shallow copy, so this also covers the ``deep=True``
+    copy that ``polydata_from_faces`` makes.
+    """
     points = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]])
     faces = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int32)
 
@@ -126,7 +115,7 @@ def test_polydata_from_faces_int32() -> None:
     assert np.array_equal(mesh.regular_faces, faces)
 
 
-@pytest.mark.skipif(not _SUPPORTS_FIXED_SIZE_STORAGE, reason="Requires fixed size cell storage")
+@pytest.mark.skipif(not SUPPORTS_FIXED_SIZE_STORAGE, reason="Requires fixed size cell storage")
 def test_polydata_from_faces_fixed_size_storage() -> None:
     """Triangles are stored without an explicit offsets array."""
     points = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]])
@@ -176,8 +165,29 @@ def test_subdivision_returns_int32() -> None:
 def test_tri_faces_from_poly_too_many_points(monkeypatch: pytest.MonkeyPatch) -> None:
     """A mesh larger than an int32 face index can address must be rejected."""
     mesh = pv.Sphere().triangulate()
-    n_points = clustering.MAX_POINTS + 1
-    monkeypatch.setattr(type(mesh), "n_points", property(lambda self: n_points))
+    monkeypatch.setattr(clustering, "MAX_POINTS", mesh.n_points - 1)
 
-    with pytest.raises(ValueError, match=f"{n_points} points, which exceeds"):
+    with pytest.raises(ValueError, match="exceeds the maximum"):
         clustering._tri_faces_from_poly(mesh)
+
+
+def test_tri_faces_from_poly_empty() -> None:
+    """An empty mesh has no faces rather than being an error."""
+    faces = clustering._tri_faces_from_poly(pv.PolyData())
+    assert faces.shape == (0, 3)
+    assert faces.dtype == np.int32
+
+
+def test_tri_faces_from_poly_quad() -> None:
+    with pytest.raises(ValueError, match="all triangles"):
+        clustering._tri_faces_from_poly(pv.Plane(i_resolution=1, j_resolution=1))
+
+
+def test_tri_faces_from_poly_mixed() -> None:
+    """A mesh of mixed cell types is rejected with the same message as a quad."""
+    points = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]])
+    mixed = pv.PolyData(points, faces=[3, 0, 1, 2, 4, 0, 1, 2, 3])
+    assert mixed.n_cells == 2
+
+    with pytest.raises(ValueError, match="all triangles"):
+        clustering._tri_faces_from_poly(mixed)


### PR DESCRIPTION
## Summary

- Build meshes with `PolyData.from_regular_faces` instead of hand-assembling a `vtkCellArray`, which removes the direct `vtkmodules` import.
- Use int32 face indices end to end, including the C++.
- Raise `pyvista>=0.42.0`, needed for `from_regular_faces` and `regular_faces`.

## The binding bug

`clustering.py` imported `vtkCellArray` from `vtkmodules` and handed it to a pyvista `PolyData`. That only holds while pyvista is built on the stock wheel — on another binding it is a different C++ type and `SetPolys` rejects it with a bare `TypeError: SetPolys argument 1:`. Rather than route the import through pyvista, `from_regular_faces` removes the need for it, so there is nothing left to mismatch. A ruff `TID251` rule now bans `vtk` and `vtkmodules` across the package so it cannot come back.

It also picks fixed-size cell storage when the VTK build supports it, so on pyvista 0.49 the offsets array disappears. On 0.42 to 0.48 the behaviour is unchanged.

## int32 faces

`clustering.cpp` hard-coded `int64_t` for faces while every other index array crossing the boundary — neighbours, edges, clusters — was already 32-bit. Since nanobind converts a mismatched dtype with a copy rather than erroring, two call sites were already paying that copy silently. Faces are now int32 throughout and `subdivision` returns int32.

Measured on a sphere with 3 subdivisions and 20000 clusters, the intermediate arrays halve: the faces array 10.7 MB to 5.3 MB, the subdivision output 42.8 MB to 21.4 MB. The returned mesh is unchanged, because `create_mesh(clean=True)` runs VTK's clean filter, which re-widens it. That is #79.

int32 indices cap input at `np.iinfo(np.int32).max` points, so `_tri_faces_from_poly` raises rather than letting indices wrap, and `SubdivideTriangles` throws `std::overflow_error` if it would emit more points than an int32 can address. Two pre-existing 32-bit truncations in the same functions are fixed alongside: an `int * int` allocation size in `PointNormals` and a `uint32_t` subscript in `RayTrace`.

Remeshing output is bit-identical to `main` — sphere and cylinder, points and faces, maxdiff 0.0. The only difference anywhere is `subdivision`'s faces dtype.

## Behaviour change

`_tri_faces_from_poly` now rejects non-triangular meshes with the same message `Clustering.__init__` already uses. Previously a quad mesh whose connectivity happened to divide by three returned silent garbage rather than raising, so this can surface an error for anyone feeding quads without noticing.

## AI Usage

Drafted with Claude Opus 5, reviewed by me before pushing. A second Claude reviewed the branch cold and found that the overflow guard I added could never fire — `nface_new` was an `int` accumulating to `4 * nface`, so it wrapped before the guard read it, and being UB the compiler could drop the check entirely. It also caught that the new triangle check regressed empty meshes to an `IndexError`. Both fixed here.
