### PR TITLE
Stop `create_mesh` flinging a centroid down a hollow

### DIFF
--- a/src/pyacvd/clustering.py
+++ b/src/pyacvd/clustering.py
@@ -36,6 +36,15 @@ MAX_THREADS = 4
 # points than an int32 can address
 MAX_POINTS = int(np.iinfo(np.int32).max)
 
+# Furthest a cluster centroid that already sits on the surface may be projected,
+# as a multiple of the size of the cluster. See ``_runaway_projection``.
+MAX_PROJECTION_RADII = 3.0
+
+# A centroid counts as sitting on the surface when the nearest face centroid is
+# within this fraction of the size of its cluster. Squared, since the distances
+# coming back from the kd-tree are squared.
+SQR_ON_SURFACE_FRACTION = 0.25
+
 
 def point_normals(mesh: PolyData) -> NDArray[T]:
     """
@@ -307,7 +316,10 @@ class Clustering:
         Parameters
         ----------
         moveclus : bool, default: True
-            Move the created points to the surface of the original mesh.
+            Move the created points to the surface of the original mesh. A point
+            that already lies on the surface and would still have to travel more
+            than ``MAX_PROJECTION_RADII`` times the size of its cluster is left
+            at the cluster centroid instead.
         flipnorm : bool, default: True
             Ensure the normals of the clustered mesh match the normals of the
             original mesh.
@@ -616,7 +628,9 @@ def create_mesh(
         The number of clusters.
     moveclus : bool
         A boolean flag to move cluster centers to the surface of their
-        corresponding cluster.
+        corresponding cluster. Centers that already lie on the surface and would
+        still have to travel more than ``MAX_PROJECTION_RADII`` times the size
+        of their cluster are left where they are.
     flipnorm : bool, default: True
         If ``True``, flip the normals of the faces.
 
@@ -649,8 +663,11 @@ def create_mesh(
     if moveclus and cnorm is not None:
         tgt_nbr = min(faces.shape[0] - 1, 1000)
         fcent = face_centroid_arrays(points, faces)
-        _, ind = neighbors(fcent, ccent, tgt_nbr, sqr_dists=True)
+        sqr_dist, ind = neighbors(fcent, ccent, tgt_nbr, sqr_dists=True)
         dist, _ = ray_trace(ccent, cnorm, points, faces, ind, num_threads=MAX_THREADS)
+
+        # Leave centroids whose ray has run away down a hollow where they are
+        dist[_runaway_projection(points, ccent, clusters, dist, sqr_dist)] = 0.0
         ccent += cnorm * dist.reshape((-1, 1))
 
     # Ignore faces that do not connect to different clusters
@@ -675,6 +692,85 @@ def create_mesh(
         f[flip_ind] = f[flip_ind, ::-1]
 
     return polydata_from_faces(v, f)
+
+
+def _runaway_projection(
+    points: NDArray_FLOAT64,
+    ccent: NDArray_FLOAT64,
+    clusters: NDArray_INT32,
+    dist: NDArray_FLOAT32_64,
+    sqr_dist: NDArray_FLOAT32_64,
+) -> npt.NDArray[np.bool_]:
+    """Return which cluster centroids must not be projected onto the surface.
+
+    A centroid is projected by casting a ray along the cluster normal and moving
+    the centroid to the first face it hits. On a hollow part, a centroid that
+    lands over a slot or a corner cut in a wall misses that wall entirely and the
+    ray carries on to hit the far side of the part, dragging the centroid through
+    the material with it (issue #70).
+
+    How far the ray travels is not on its own enough to tell the two apart. On a
+    surface of revolution the clusters come out as rings, and a ring's area
+    weighted centroid sits on the axis with its normal along it, so the ray
+    legitimately runs all the way out to the tip. On
+    ``pyvista.Cone(height=128, resolution=20)`` that is 11.99 times the radius of
+    the cluster, further than any of the runaways below.
+
+    What does tell them apart is where the centroid started. The centroid of the
+    ring above is out on the axis, a full cluster radius clear of any face, and
+    the projection is closing a real gap. The centroid of a runaway is already
+    sitting on the wall its cluster covers, a fraction of the cluster size from
+    the nearest face, and so has nowhere to go. Only refuse the projection when
+    both hold: the nearest face is within ``SQR_ON_SURFACE_FRACTION`` of the
+    cluster size, and the ray travels more than ``MAX_PROJECTION_RADII`` of them.
+
+    Measured across a corpus of 43 meshes (cones and conical holes from
+    ``height=0.5`` to ``128``, cylinders, spheres, tori, an urn, cow, cow head,
+    human, louis, airplane, gears, ant, a room scan, plates and platonics) from
+    10 to 20000 clusters at 0 to 3 subdivisions, the only meshes landing in that
+    corner are the ones that are hollow, plus two clusters on the ant whose rays
+    run 0.03% of its bounding box and so make no odds either way. Both edges are
+    tight and neither holds on its own: the runaways run 3.09 to 9.49 cluster
+    radii where a mesh that is not hollow gets no further than 2.57, and they sit
+    0.16 to 0.46 of a cluster size from the surface where one that is not hollow
+    gets no closer than 0.52.
+
+    Parameters
+    ----------
+    points : numpy.ndarray
+        Points of the mesh being clustered.
+    ccent : numpy.ndarray
+        Cluster centroids.
+    clusters : numpy.ndarray
+        Cluster index of each point.
+    dist : numpy.ndarray
+        Distance the ray cast from each centroid travelled.
+    sqr_dist : numpy.ndarray
+        Squared distances from each cluster centroid to the nearest face
+        centroids, sorted nearest first.
+
+    Returns
+    -------
+    numpy.ndarray
+        ``True`` for each centroid that must be left where it is.
+
+    """
+    if np.any(clusters == -1):
+        clusters = np.where(clusters == -1, clusters.max() + 1, clusters)
+
+    delta = points - ccent[clusters]
+    sqr_radius = np.zeros(ccent.shape[0])
+    np.maximum.at(sqr_radius, clusters, (delta * delta).sum(axis=1))
+
+    # A cluster of a single point has no radius of its own, so fall back on how
+    # far its neighbours are. Reach a few faces out rather than to the first,
+    # which is only about a third of an edge away and next to a sliver less
+    # than that.
+    ring = min(3, sqr_dist.shape[1] - 1)
+    sqr_size = np.maximum(sqr_radius, sqr_dist[:, ring])
+
+    on_surface = sqr_dist[:, 0] < SQR_ON_SURFACE_FRACTION * sqr_size
+    return on_surface & (dist * dist > MAX_PROJECTION_RADII**2 * sqr_size)
 
 
 def _cluster_centroid(

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -85,6 +85,130 @@ def test_cow() -> None:
     assert remesh.n_points
 
 
+def _slotted_wall() -> pv.PolyData:
+    """Return a wall with a slot cut into it and a second wall parallel behind it.
+
+    The slot is one row of faces wide, which is what issue #70 looks like: a
+    cluster covering the wall either side of it has its centroid land in the
+    slot, a fraction of the cluster across from the material it sits on, and the
+    ray cast from it goes straight through and hits the wall behind.
+
+    Built by hand rather than with a boolean so the point order, and with it the
+    clustering, does not depend on the VTK version.
+    """
+    n, size, gap = 20, 10.0, 5.0
+    t = np.linspace(0.0, size, n + 1)
+    xx, yy = np.meshgrid(t, t, indexing="ij")
+    plate = np.column_stack((xx.ravel(), yy.ravel(), np.zeros(xx.size)))
+
+    ind = np.arange(plate.shape[0]).reshape(n + 1, n + 1)
+    a, b = ind[:-1, :-1].ravel(), ind[1:, :-1].ravel()
+    c, d = ind[1:, 1:].ravel(), ind[:-1, 1:].ravel()
+    tri = np.vstack((np.column_stack((a, b, c)), np.column_stack((a, c, d))))
+
+    # cut a slot into the front wall, running in from one edge
+    cent = plate[tri].mean(axis=1)
+    half = size / n / 2
+    in_slot = (np.abs(cent[:, 1] - size / 2) < half) & (cent[:, 0] < 0.7 * size)
+
+    points = np.vstack((plate, plate - [0.0, 0.0, gap]))
+    faces = np.vstack((tri[~in_slot], tri + plate.shape[0]))
+    used, faces = np.unique(faces, return_inverse=True)  # drop the slot's points
+    return pv.PolyData.from_regular_faces(points[used], faces.reshape(-1, 3).astype(np.int32))
+
+
+@pytest.mark.parametrize("nclus", [40, 50, 60, 110, 120, 130, 150, 180, 320])
+def test_create_mesh_over_slot(nclus: int) -> None:
+    """Cluster centroids must not be projected onto the far wall of a hollow part.
+
+    A cluster covering the wall either side of the slot has its centroid land
+    over the void. The ray cast from it misses the wall the cluster sits on and
+    hits the wall behind, dragging the point across the part and leaving a wedge
+    of long triangles behind it.
+
+    Both walls are flat, so every centroid already lies on the wall it belongs
+    to and projecting must not move a single one. Each of these cluster counts
+    moves one of them by the full five unit gap without the fix.
+
+    https://github.com/pyvista/pyacvd/issues/70
+    """
+    clus = pyacvd.Clustering(_slotted_wall())
+    clus.cluster(nclus)
+
+    assert np.array_equal(clus.create_mesh().points, clus.create_mesh(moveclus=False).points)
+
+
+def test_create_mesh_onto_cone_tip() -> None:
+    """A centroid that is genuinely off the surface must still be projected.
+
+    Clustering a surface of revolution gives rings of clusters. A ring's area
+    weighted centroid sits on the axis and its mean normal cancels radially and
+    points along it, so the ray legitimately runs out of the tip of the cone.
+    That is several cluster radii, further than the runaway of the slot above,
+    and refusing it leaves the point stranded inside the cone.
+    """
+    clus = pyacvd.Clustering(pv.Cone(height=2.0, resolution=40).triangulate())
+    clus.subdivide(3)
+    clus.cluster(25)
+
+    moved = clus.create_mesh()
+    unmoved = clus.create_mesh(moveclus=False)
+
+    # the projection has work to do here, unlike on the slotted wall
+    assert np.linalg.norm(moved.points - unmoved.points, axis=1).max() > 0.5
+
+    # and every point it moves lands on the cone
+    _, closest = clus.mesh.find_closest_cell(moved.points, return_closest_point=True)
+    assert np.linalg.norm(moved.points - closest, axis=1).max() < 1e-9
+
+    _, closest = clus.mesh.find_closest_cell(unmoved.points, return_closest_point=True)
+    assert np.linalg.norm(unmoved.points - closest, axis=1).max() > 0.1
+
+
+def test_runaway_projection() -> None:
+    """Only a centroid already on the surface may have its projection refused."""
+    # three clusters of two points, each one unit either side of its centroid
+    points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]] * 3)
+    clusters = np.array([0, 0, 1, 1, 2, 2], dtype=np.int32)
+    ccent = np.zeros((3, 3))
+
+    # the first two sit on the surface, a fifth of a cluster from it, the third
+    # is six tenths away and so is closing a real gap
+    sqr_dist = np.repeat([[0.04], [0.04], [0.36]], 4, axis=1)
+
+    dist = np.array([3.001, 2.999, 100.0])
+    mask = clustering._runaway_projection(points, ccent, clusters, dist, sqr_dist)
+
+    assert mask.tolist() == [True, False, False]
+    assert clustering._runaway_projection(points, ccent, clusters, -dist, sqr_dist).tolist() == [
+        True,
+        False,
+        False,
+    ]
+
+
+def test_runaway_projection_reaches_past_the_nearest_face() -> None:
+    """A cluster of one point is sized by its neighbourhood, not the nearest face.
+
+    Such a cluster has no radius of its own and the nearest face centroid is only
+    about a third of an edge away, so sizing it by that alone refuses ordinary
+    projections. The faces here run out from ``0.1`` to ``1.2``; the fourth of
+    them gives a limit of ``1.2`` rather than the ``0.3`` of the nearest, and
+    reaching further out than that stops refusing anything at all.
+    """
+    points = np.zeros((1, 3))
+    clusters = np.zeros(1, dtype=np.int32)
+    ccent = np.zeros((1, 3))
+    sqr_dist = (np.arange(1, 13) / 10.0) ** 2
+    sqr_dist = sqr_dist.reshape(1, -1)
+
+    kept = clustering._runaway_projection(points, ccent, clusters, np.array([1.0]), sqr_dist)
+    refused = clustering._runaway_projection(points, ccent, clusters, np.array([1.3]), sqr_dist)
+
+    assert not kept[0]
+    assert refused[0]
+
+
 def test_polydata_from_faces() -> None:
     points = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]])
     faces = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int64)


### PR DESCRIPTION
## Summary

Resolves #70. `create_mesh(moveclus=True)` could fling a cluster centroid clean through a part, leaving a wedge across the opening of a channel section.

## What happens

`moveclus` projects each cluster centroid onto the surface along the cluster normal. On a hollow section, a cluster lying flat on a wall can have an area-weighted centroid that lands just off the material, over a slot cut in that wall. The ray misses the near wall, runs down the hollow — the side walls are parallel to it, so they fail the `|det| < EPSILON` test and are skipped — and hits the far wall instead. On the reporter's mesh 3 of 17562 clusters came back at 87 units, the depth of the section, where legitimate projections top out around 4.

There is no nearer intersection to find; brute-forcing all 151888 faces returns the same 87. `moveclus` and `ray_trace` arrived in v0.3.0, which is why 0.2 was fine.

## The fix

Leave the centroid unprojected when the ray has clearly skimmed off down a hollow, which is what 0.2.x did. Two conditions must both hold: the centroid already sat on the surface before projecting, and the ray then travelled more than three cluster-sizes.

The first condition is what makes this safe. A centroid that starts *off* the surface is closing a real gap and must keep its projection — a cone apex is the clean example, where ACVD produces ring-shaped clusters whose centroid lands on the axis of revolution and whose ray legitimately exits through the tip. An earlier version of this patch capped on distance alone and broke exactly that case, taking a cone from a surface deviation of 0 to 0.18.

Reporter's mesh: max edge 91.40 to 33.76, against 30.94 for `moveclus=False`. The extracted component in #70's attachment goes 89.26 to 25.56, matching `moveclus=False` exactly.

Verified unchanged across 566 remeshes over 43 meshes — cones from height 0.5 to 128, conical countersinks, cylinders, spheres, tori, and the usual example meshes. The only outputs that move are the hollow ones: the two meshes from the issue, the synthetic wall, and a room scan whose max edge improves.

Keeping `moveclus=True` as the default. Away from this defect it is a real accuracy gain — p99 distance from output points to the input surface is 0.0 on 0.3.x against 2.63 on 0.2.11.

## Caveats

Both thresholds are empirical and neither margin is wide. Across the corpus, runaway projections run 3.09 to 9.49 cluster-sizes while the closest legitimate approach from a non-hollow mesh is 2.57; the on-surface ratio separates 0.162–0.462 from 0.517. The constants sit near the geometric midpoint of each pair.

Two of 41 cluster counts on the synthetic wall still fling a point. Loosening either threshold enough to catch them starts suppressing legitimate projections on the cow, human and airplane meshes, so I left them.

A principled version would use the hit face index, which `ray_trace` already returns and `create_mesh` currently discards: a legitimate hit lands on a face near the cluster in mesh connectivity, a runaway lands on an unrelated wall. That is a larger change and wants its own PR.

## AI Usage

Drafted with Claude Opus 5, reviewed by me before pushing. A second Claude reviewed the first version cold and found it made cones worse, which is what produced the on-surface condition; it also found the original test passed with the cap disabled entirely. Threshold corpus, the 566-config comparison and the mutation check are all its work, spot-checked by me.
