### PR TITLE
Trace rays against a BVH instead of the nearest face centroids

### DIFF
--- a/src/bvh.hpp
+++ b/src/bvh.hpp
@@ -1,0 +1,382 @@
+#ifndef PYACVD_BVH_HEADER_H
+#define PYACVD_BVH_HEADER_H
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+// -----------------------------------------------------------------------------
+// Bounding volume hierarchy over a triangle surface
+// -----------------------------------------------------------------------------
+//
+// A top-down, median-split BVH used to find, for each of many rays, the
+// intersection with the surface nearest the ray's origin.
+//
+// The alternative it replaces is to take the faces whose centroids are nearest
+// the origin and test those. That is approximate twice over: the face a ray
+// actually hits need not be among the nearest by centroid, and a ray can hit a
+// face whose centroid is far away while missing every near one. Widening the
+// candidate list narrows the error without closing it, and the k-nearest search
+// needed to build the list costs more than this whole structure.
+//
+// Build is O(n log n) and single-threaded. Queries are independent and read
+// only, so a caller is free to run them in parallel, but nothing here does.
+// -----------------------------------------------------------------------------
+
+namespace pyacvd_bvh {
+
+// Faces per leaf. Ray-triangle tests are cheap, so large leaves trade a little
+// query time for a shallower tree and a faster build.
+static constexpr int BVH_LEAF_SIZE = 128;
+
+// Deep enough for any tree a median split can produce: it halves the face count
+// at every level, so depth stays under 64 for face counts an int can hold.
+static constexpr int BVH_STACK_SIZE = 128;
+
+// Rejects rays within rounding of parallel to a triangle's plane.
+static constexpr double BVH_DET_EPS = 1e-6;
+
+// Barycentric slack, so a ray passing exactly along a shared edge hits one of
+// the two faces rather than slipping between them.
+static constexpr double BVH_TRI_EPS = 1e-6;
+
+// Guards the split axis against a set of faces whose centroids coincide.
+static constexpr double BVH_BUILD_EPS = 1e-12;
+
+// A node is a leaf when ``count > 0``, in which case ``left`` indexes the first
+// of its faces in ``prim_indices``. Otherwise ``left`` indexes its left child
+// and the right child follows immediately after it.
+struct Node {
+    double bmin[3];
+    double bmax[3];
+    int32_t left;
+    int32_t count;
+};
+
+// ``T`` is the scalar the caller stores its vertices in. Everything computed
+// here is double regardless, so a float32 surface is traced at the same
+// precision without being copied up first.
+template <typename T> struct BVH {
+    std::vector<Node> nodes;
+    std::vector<int32_t> prim_indices;
+    std::vector<double> tri_bmin;
+    std::vector<double> tri_bmax;
+    std::vector<double> tri_centroid;
+
+    // Borrowed. The caller keeps the arrays alive for the lifetime of the tree.
+    const T *vertices = nullptr;
+    const int32_t *faces = nullptr;
+    int nfaces = 0;
+};
+
+template <typename T> inline void compute_tri_aabbs(BVH<T> &bvh) {
+    const int nfaces = bvh.nfaces;
+    const T *v = bvh.vertices;
+    const int32_t *f = bvh.faces;
+    for (int i = 0; i < nfaces; ++i) {
+        bvh.prim_indices[i] = i;
+        const int64_t i0 = f[i * 3 + 0];
+        const int64_t i1 = f[i * 3 + 1];
+        const int64_t i2 = f[i * 3 + 2];
+        for (int k = 0; k < 3; ++k) {
+            const double a = v[i0 * 3 + k];
+            const double b = v[i1 * 3 + k];
+            const double c = v[i2 * 3 + k];
+            bvh.tri_bmin[i * 3 + k] = std::min(a, std::min(b, c));
+            bvh.tri_bmax[i * 3 + k] = std::max(a, std::max(b, c));
+            bvh.tri_centroid[i * 3 + k] = (a + b + c) * (1.0 / 3.0);
+        }
+    }
+}
+
+// Build a tree over ``nfaces`` triangles, splitting each node at the median
+// face centroid along the axis its centroids are most spread over.
+template <typename T>
+inline void bvh_build(BVH<T> &bvh, const T *vertices, const int32_t *faces, int nfaces) {
+    bvh.vertices = vertices;
+    bvh.faces = faces;
+    bvh.nfaces = nfaces;
+    bvh.nodes.clear();
+    if (nfaces <= 0) {
+        return;
+    }
+
+    bvh.tri_bmin.assign(static_cast<size_t>(nfaces) * 3, 0.0);
+    bvh.tri_bmax.assign(static_cast<size_t>(nfaces) * 3, 0.0);
+    bvh.tri_centroid.assign(static_cast<size_t>(nfaces) * 3, 0.0);
+    bvh.prim_indices.assign(nfaces, 0);
+    compute_tri_aabbs(bvh);
+
+    const size_t max_leaves =
+        (static_cast<size_t>(nfaces) + BVH_LEAF_SIZE - 1) / BVH_LEAF_SIZE;
+    bvh.nodes.reserve(max_leaves * 2 + 1);
+    bvh.nodes.emplace_back();
+
+    struct Task {
+        int node_idx;
+        int first;
+        int count;
+    };
+    std::vector<Task> stack;
+    stack.reserve(64);
+    stack.push_back({0, 0, nfaces});
+
+    const double inf = std::numeric_limits<double>::infinity();
+
+    while (!stack.empty()) {
+        const Task task = stack.back();
+        stack.pop_back();
+
+        // Bounds over the faces themselves, and separately over their
+        // centroids, which is what the split is chosen from
+        double bmin[3] = {inf, inf, inf};
+        double bmax[3] = {-inf, -inf, -inf};
+        double cmin[3] = {inf, inf, inf};
+        double cmax[3] = {-inf, -inf, -inf};
+        for (int i = task.first; i < task.first + task.count; ++i) {
+            const int tri = bvh.prim_indices[i];
+            for (int k = 0; k < 3; ++k) {
+                bmin[k] = std::min(bmin[k], bvh.tri_bmin[tri * 3 + k]);
+                bmax[k] = std::max(bmax[k], bvh.tri_bmax[tri * 3 + k]);
+                cmin[k] = std::min(cmin[k], bvh.tri_centroid[tri * 3 + k]);
+                cmax[k] = std::max(cmax[k], bvh.tri_centroid[tri * 3 + k]);
+            }
+        }
+        for (int k = 0; k < 3; ++k) {
+            bvh.nodes[task.node_idx].bmin[k] = bmin[k];
+            bvh.nodes[task.node_idx].bmax[k] = bmax[k];
+        }
+
+        int axis = 0;
+        const double ext[3] = {cmax[0] - cmin[0], cmax[1] - cmin[1], cmax[2] - cmin[2]};
+        if (ext[1] > ext[0] && ext[1] >= ext[2])
+            axis = 1;
+        else if (ext[2] > ext[0] && ext[2] >= ext[1])
+            axis = 2;
+
+        // Stop when the node is small enough, or when its centroids are so
+        // nearly coincident that a split cannot separate them
+        if (task.count <= BVH_LEAF_SIZE || ext[axis] < BVH_BUILD_EPS) {
+            bvh.nodes[task.node_idx].left = task.first;
+            bvh.nodes[task.node_idx].count = task.count;
+            continue;
+        }
+
+        const int mid = task.first + task.count / 2;
+        const double *centroids = bvh.tri_centroid.data();
+        std::nth_element(
+            bvh.prim_indices.begin() + task.first,
+            bvh.prim_indices.begin() + mid,
+            bvh.prim_indices.begin() + task.first + task.count,
+            [centroids, axis](int32_t a, int32_t b) {
+                return centroids[a * 3 + axis] < centroids[b * 3 + axis];
+            });
+
+        const int left_idx = static_cast<int>(bvh.nodes.size());
+        bvh.nodes.emplace_back();
+        bvh.nodes.emplace_back();
+        bvh.nodes[task.node_idx].left = left_idx;
+        bvh.nodes[task.node_idx].count = 0;
+
+        stack.push_back({left_idx + 1, mid, task.first + task.count - mid});
+        stack.push_back({left_idx, task.first, mid - task.first});
+    }
+}
+
+// Slab test of a ray against an axis-aligned box, writing the time at which the
+// ray enters it into ``t_enter``. Returns whether the box is met within
+// ``[t_lo, t_hi]``.
+inline bool ray_aabb(
+    const double origin[3],
+    const double dir[3],
+    const double inv_dir[3],
+    const double bmin[3],
+    const double bmax[3],
+    const double t_lo,
+    const double t_hi,
+    double &t_enter) {
+    double tmin = -std::numeric_limits<double>::infinity();
+    double tmax = std::numeric_limits<double>::infinity();
+
+    for (int k = 0; k < 3; ++k) {
+        if (std::abs(dir[k]) < 1e-30) {
+            // Parallel to this pair of slabs: either inside them for all t or
+            // outside for all t
+            if (origin[k] < bmin[k] || origin[k] > bmax[k])
+                return false;
+            continue;
+        }
+        double t1 = (bmin[k] - origin[k]) * inv_dir[k];
+        double t2 = (bmax[k] - origin[k]) * inv_dir[k];
+        if (t1 > t2)
+            std::swap(t1, t2);
+        tmin = std::max(tmin, t1);
+        tmax = std::min(tmax, t2);
+        if (tmin > tmax)
+            return false;
+    }
+
+    t_enter = tmin;
+    return tmax >= t_lo && tmin <= t_hi;
+}
+
+// Moller-Trumbore ray-triangle intersection. On a hit, ``t`` is the signed
+// distance along ``dir``, which is assumed to be of unit length.
+template <typename T>
+inline bool ray_triangle(
+    const double origin[3],
+    const double dir[3],
+    const T *v0,
+    const T *v1,
+    const T *v2,
+    double &t) {
+    const double e1[3] = {
+        double(v1[0]) - double(v0[0]),
+        double(v1[1]) - double(v0[1]),
+        double(v1[2]) - double(v0[2])};
+    const double e2[3] = {
+        double(v2[0]) - double(v0[0]),
+        double(v2[1]) - double(v0[1]),
+        double(v2[2]) - double(v0[2])};
+
+    const double p[3] = {
+        dir[1] * e2[2] - dir[2] * e2[1],
+        dir[2] * e2[0] - dir[0] * e2[2],
+        dir[0] * e2[1] - dir[1] * e2[0]};
+
+    const double det = e1[0] * p[0] + e1[1] * p[1] + e1[2] * p[2];
+    if (std::abs(det) < BVH_DET_EPS)
+        return false;
+    const double inv_det = 1.0 / det;
+
+    const double s[3] = {
+        origin[0] - double(v0[0]), origin[1] - double(v0[1]), origin[2] - double(v0[2])};
+    const double u = (s[0] * p[0] + s[1] * p[1] + s[2] * p[2]) * inv_det;
+    if (u < -BVH_TRI_EPS || u > 1.0 + BVH_TRI_EPS)
+        return false;
+
+    const double q[3] = {
+        s[1] * e1[2] - s[2] * e1[1],
+        s[2] * e1[0] - s[0] * e1[2],
+        s[0] * e1[1] - s[1] * e1[0]};
+
+    const double vv = (dir[0] * q[0] + dir[1] * q[1] + dir[2] * q[2]) * inv_det;
+    if (vv < -BVH_TRI_EPS || u + vv > 1.0 + BVH_TRI_EPS)
+        return false;
+
+    t = (e2[0] * q[0] + e2[1] * q[1] + e2[2] * q[2]) * inv_det;
+    return true;
+}
+
+// Trace one ray, returning the index of the face it hits, or -1 for a miss.
+//
+// ``t_hit`` is set to the signed distance along ``dir``. When ``in_vector`` the
+// ray only travels forwards and the hit is the one with the smallest positive
+// distance; otherwise it travels both ways and the hit is the one nearest the
+// origin in either direction.
+template <typename T>
+inline int bvh_trace_ray(
+    const BVH<T> &bvh,
+    const double origin[3],
+    const double dir[3],
+    const bool in_vector,
+    double &t_hit) {
+    t_hit = std::numeric_limits<double>::infinity();
+    if (bvh.nodes.empty()) {
+        return -1;
+    }
+
+    double inv_dir[3];
+    for (int k = 0; k < 3; ++k) {
+        inv_dir[k] = (std::abs(dir[k]) >= 1e-30) ? 1.0 / dir[k] : 0.0;
+    }
+
+    double best_t = std::numeric_limits<double>::infinity();
+    double best_abs = std::numeric_limits<double>::infinity();
+    int best_idx = -1;
+
+    int stack[BVH_STACK_SIZE];
+    int sp = 0;
+    stack[sp++] = 0;
+
+    while (sp > 0) {
+        const Node &node = bvh.nodes[stack[--sp]];
+
+        // Prune against the best hit so far. Travelling both ways, that is an
+        // interval straddling the origin rather than one running forward
+        const double t_lo = in_vector ? 0.0 : -best_abs;
+        const double t_hi = in_vector ? best_t : best_abs;
+
+        double t_enter;
+        if (!ray_aabb(origin, dir, inv_dir, node.bmin, node.bmax, t_lo, t_hi, t_enter)) {
+            continue;
+        }
+
+        if (node.count > 0) {
+            const T *v = bvh.vertices;
+            const int32_t *f = bvh.faces;
+            const int32_t *prims = bvh.prim_indices.data();
+            for (int i = node.left; i < node.left + node.count; ++i) {
+                const int tri = prims[i];
+                const int64_t i0 = f[tri * 3 + 0];
+                const int64_t i1 = f[tri * 3 + 1];
+                const int64_t i2 = f[tri * 3 + 2];
+                double t;
+                if (!ray_triangle(origin, dir, &v[i0 * 3], &v[i1 * 3], &v[i2 * 3], t))
+                    continue;
+                if (in_vector) {
+                    if (t > 0.0 && t < best_t) {
+                        best_t = t;
+                        best_idx = tri;
+                    }
+                } else if (std::abs(t) < best_abs) {
+                    best_abs = std::abs(t);
+                    best_t = t;
+                    best_idx = tri;
+                }
+            }
+            continue;
+        }
+
+        // Internal. Push the further child first so the nearer one is popped
+        // next and tightens the pruning interval before the far one is opened.
+        const int left = node.left;
+        const Node &nl = bvh.nodes[left];
+        const Node &nr = bvh.nodes[left + 1];
+
+        double tl, tr;
+        const bool hit_l = ray_aabb(origin, dir, inv_dir, nl.bmin, nl.bmax, t_lo, t_hi, tl);
+        const bool hit_r = ray_aabb(origin, dir, inv_dir, nr.bmin, nr.bmax, t_lo, t_hi, tr);
+
+        if (hit_l && hit_r) {
+            if (sp + 2 > BVH_STACK_SIZE)
+                continue;
+            const double key_l = in_vector ? tl : std::abs(tl);
+            const double key_r = in_vector ? tr : std::abs(tr);
+            if (key_l < key_r) {
+                stack[sp++] = left + 1;
+                stack[sp++] = left;
+            } else {
+                stack[sp++] = left;
+                stack[sp++] = left + 1;
+            }
+        } else if (hit_l) {
+            if (sp + 1 > BVH_STACK_SIZE)
+                continue;
+            stack[sp++] = left;
+        } else if (hit_r) {
+            if (sp + 1 > BVH_STACK_SIZE)
+                continue;
+            stack[sp++] = left + 1;
+        }
+    }
+
+    t_hit = best_t;
+    return best_idx;
+}
+
+} // namespace pyacvd_bvh
+
+#endif

--- a/src/bvh.hpp
+++ b/src/bvh.hpp
@@ -35,8 +35,14 @@ static constexpr int BVH_LEAF_SIZE = 128;
 // at every level, so depth stays under 64 for face counts an int can hold.
 static constexpr int BVH_STACK_SIZE = 128;
 
-// Rejects rays within rounding of parallel to a triangle's plane.
-static constexpr double BVH_DET_EPS = 1e-6;
+// Rejects rays within rounding of parallel to a triangle's plane. The
+// Moller-Trumbore determinant is ``d . (e1 x e2)``, so for a unit direction it
+// is the sine of the angle between the ray and the plane times twice the area
+// of the triangle. Comparing it against a fixed number therefore rejects every
+// small triangle whatever the angle: at 1e-6 that is 99.7% of the faces of the
+// Stanford bunny subdivided once, whose rays then hit nothing at all. Divide
+// the area back out and the test measures the angle alone, in any unit.
+static constexpr double BVH_DET_EPS = 1e-9;
 
 // Barycentric slack, so a ray passing exactly along a shared edge hits one of
 // the two faces rather than slipping between them.
@@ -65,6 +71,10 @@ template <typename T> struct BVH {
     std::vector<double> tri_bmax;
     std::vector<double> tri_centroid;
 
+    // Squared area scale of each face, ``|e1 x e2|^2``, which the determinant
+    // is measured against
+    std::vector<double> tri_sqr_scale;
+
     // Borrowed. The caller keeps the arrays alive for the lifetime of the tree.
     const T *vertices = nullptr;
     const int32_t *faces = nullptr;
@@ -88,6 +98,20 @@ template <typename T> inline void compute_tri_aabbs(BVH<T> &bvh) {
             bvh.tri_bmax[i * 3 + k] = std::max(a, std::max(b, c));
             bvh.tri_centroid[i * 3 + k] = (a + b + c) * (1.0 / 3.0);
         }
+
+        const double e1[3] = {
+            double(v[i1 * 3 + 0]) - double(v[i0 * 3 + 0]),
+            double(v[i1 * 3 + 1]) - double(v[i0 * 3 + 1]),
+            double(v[i1 * 3 + 2]) - double(v[i0 * 3 + 2])};
+        const double e2[3] = {
+            double(v[i2 * 3 + 0]) - double(v[i0 * 3 + 0]),
+            double(v[i2 * 3 + 1]) - double(v[i0 * 3 + 1]),
+            double(v[i2 * 3 + 2]) - double(v[i0 * 3 + 2])};
+        const double n[3] = {
+            e1[1] * e2[2] - e1[2] * e2[1],
+            e1[2] * e2[0] - e1[0] * e2[2],
+            e1[0] * e2[1] - e1[1] * e2[0]};
+        bvh.tri_sqr_scale[i] = n[0] * n[0] + n[1] * n[1] + n[2] * n[2];
     }
 }
 
@@ -106,6 +130,7 @@ inline void bvh_build(BVH<T> &bvh, const T *vertices, const int32_t *faces, int 
     bvh.tri_bmin.assign(static_cast<size_t>(nfaces) * 3, 0.0);
     bvh.tri_bmax.assign(static_cast<size_t>(nfaces) * 3, 0.0);
     bvh.tri_centroid.assign(static_cast<size_t>(nfaces) * 3, 0.0);
+    bvh.tri_sqr_scale.assign(static_cast<size_t>(nfaces), 0.0);
     bvh.prim_indices.assign(nfaces, 0);
     compute_tri_aabbs(bvh);
 
@@ -231,6 +256,7 @@ inline bool ray_triangle(
     const T *v0,
     const T *v1,
     const T *v2,
+    const double sqr_scale,
     double &t) {
     const double e1[3] = {
         double(v1[0]) - double(v0[0]),
@@ -246,8 +272,15 @@ inline bool ray_triangle(
         dir[2] * e2[0] - dir[0] * e2[2],
         dir[0] * e2[1] - dir[1] * e2[0]};
 
+    // ``det`` is the sine of the angle between the ray and the plane of the
+    // triangle, times ``|e1 x e2|``. Compare the two squared so that the test
+    // is on the angle alone and needs no square root.
+    // A face of no area has no plane to intersect, and would otherwise divide
+    // through by a determinant of zero
+    if (sqr_scale <= 0.0)
+        return false;
     const double det = e1[0] * p[0] + e1[1] * p[1] + e1[2] * p[2];
-    if (std::abs(det) < BVH_DET_EPS)
+    if (det * det < BVH_DET_EPS * BVH_DET_EPS * sqr_scale)
         return false;
     const double inv_det = 1.0 / det;
 
@@ -324,7 +357,14 @@ inline int bvh_trace_ray(
                 const int64_t i1 = f[tri * 3 + 1];
                 const int64_t i2 = f[tri * 3 + 2];
                 double t;
-                if (!ray_triangle(origin, dir, &v[i0 * 3], &v[i1 * 3], &v[i2 * 3], t))
+                if (!ray_triangle(
+                        origin,
+                        dir,
+                        &v[i0 * 3],
+                        &v[i1 * 3],
+                        &v[i2 * 3],
+                        bvh.tri_sqr_scale[tri],
+                        t))
                     continue;
                 if (in_vector) {
                     if (t > 0.0 && t < best_t) {

--- a/src/clustering.cpp
+++ b/src/clustering.cpp
@@ -10,6 +10,7 @@
 #include <nanobind/ndarray.h>
 
 #include "array_support.h"
+#include "bvh.hpp"
 
 #ifdef _MSC_VER
 #define restrict __restrict
@@ -251,119 +252,53 @@ FaceNormals(const NDArray<const T, 2> points, const NDArray<const int32_t, 2> fa
     return fnorm_arr;
 }
 
+// Move a set of points onto a triangle surface along a set of directions.
+//
+// For each origin/direction pair, returns the signed distance to the nearest
+// intersection with the surface and the index of the face hit. A ray that hits
+// nothing gets a distance of zero and an index of -1, so that a caller applying
+// the distance leaves such a point where it is.
+//
+// ``in_vector`` restricts a ray to travelling forwards along its direction.
+// Otherwise it travels both ways and takes whichever hit is nearest its origin.
 template <typename T>
 nb::tuple RayTrace(
     NDArray<const T, 2> source_pt_arr,
     NDArray<const T, 2> source_n_arr,
     NDArray<const T, 2> v_arr,
     NDArray<const int32_t, 2> f_arr,
-    NDArray<const uint32_t, 2> idx_arr,
-    const bool no_inf,                // true
-    const int num_threads,            // -1
-    const uint32_t out_of_bounds_idx, // 0 or max targets
-    const bool in_vector) {           // false
+    const bool in_vector) {
 
     const T *source_pt = source_pt_arr.data();
     const T *source_n = source_n_arr.data();
-    const T *v = v_arr.data();
-    const int32_t *f = f_arr.data();
-    const uint32_t *idx = idx_arr.data();
 
-    const size_t nfaces = f_arr.shape(0);
+    const int npoints = static_cast<int>(source_pt_arr.shape(0));
+    if (source_n_arr.shape(0) != source_pt_arr.shape(0)) {
+        throw std::runtime_error("Must have one direction per source point");
+    }
 
-    int npoints = source_pt_arr.shape(0);
-    size_t tgt_nbr = idx_arr.shape(1);                  // number of target neighbors
-    auto dists_arr = MakeNDArray<T, 1>({(int)npoints}); // dist to nearest face
-    T *dists = dists_arr.data();
-
-    // Index of the nearest face
+    auto dists_arr = MakeNDArray<T, 1>({npoints});
     auto near_ind_arr = MakeNDArray<int, 1>({npoints});
+    T *dists = dists_arr.data();
     int *near_ind = near_ind_arr.data();
 
-    // Loop through each face and determine intersections
-    for (size_t i = 0; i < npoints; i++) {
-        T prev_dist = std::numeric_limits<T>::infinity();
-        int near_idx = -1;
+    pyacvd_bvh::BVH<T> bvh;
+    pyacvd_bvh::bvh_build(bvh, v_arr.data(), f_arr.data(), static_cast<int>(f_arr.shape(0)));
 
-        T source_n0 = source_n[i * 3 + 0];
-        T source_n1 = source_n[i * 3 + 1];
-        T source_n2 = source_n[i * 3 + 2];
+    for (int i = 0; i < npoints; i++) {
+        const double origin[3] = {
+            static_cast<double>(source_pt[i * 3 + 0]),
+            static_cast<double>(source_pt[i * 3 + 1]),
+            static_cast<double>(source_pt[i * 3 + 2])};
+        const double dir[3] = {
+            static_cast<double>(source_n[i * 3 + 0]),
+            static_cast<double>(source_n[i * 3 + 1]),
+            static_cast<double>(source_n[i * 3 + 2])};
 
-        T source_p0 = source_pt[i * 3 + 0];
-        T source_p1 = source_pt[i * 3 + 1];
-        T source_p2 = source_pt[i * 3 + 2];
-
-        for (size_t j = 0; j < tgt_nbr; ++j) {
-            uint32_t ind = idx[i * tgt_nbr + j];
-            if (UNLIKELY(out_of_bounds_idx && out_of_bounds_idx == ind))
-                break;
-
-            // Compute edges for this triangle. We do this here rather than
-            // pre-computing all since we're exiting on the first intersection
-            //
-            // ind is a uint32, so scale it in size_t to avoid wrapping
-            const size_t find = static_cast<size_t>(ind) * 3;
-            int64_t i0 = f[find + 0];
-            int64_t i1 = f[find + 1];
-            int64_t i2 = f[find + 2];
-
-            T e1[3], e2[3];
-            for (int k = 0; k < 3; k++) {
-                T vertex = v[i0 * 3 + k];
-                e1[k] = v[i1 * 3 + k] - vertex;
-                e2[k] = v[i2 * 3 + k] - vertex;
-            }
-
-            // calculate the determinant
-            T p0 = source_n1 * e2[2] - source_n2 * e2[1];
-            T p1 = source_n2 * e2[0] - source_n0 * e2[2];
-            T p2 = source_n0 * e2[1] - source_n1 * e2[0];
-
-            T det = e1[0] * p0 + e1[1] * p1 + e1[2] * p2;
-            if (UNLIKELY(std::abs(det) < EPSILON))
-                continue;
-            T inv_det = 1.0 / det;
-
-            T t0 = source_p0 - v[i0 * 3 + 0];
-            T t1 = source_p1 - v[i0 * 3 + 1];
-            T t2 = source_p2 - v[i0 * 3 + 2];
-
-            T u = (t0 * p0 + t1 * p1 + t2 * p2) * inv_det;
-            if (u < -EPSILON || u > 1.0 + EPSILON)
-                continue;
-
-            T q0 = t1 * e1[2] - t2 * e1[1];
-            T q1 = t2 * e1[0] - t0 * e1[2];
-            T q2 = t0 * e1[1] - t1 * e1[0];
-            T vtest = (source_n0 * q0 + source_n1 * q1 + source_n2 * q2) * inv_det;
-            if (vtest < -EPSILON || u + vtest > 1.0 + EPSILON)
-                continue;
-
-            if (u + vtest < 1.0 + EPSILON) {
-                T dist = (e2[0] * q0 + e2[1] * q1 + e2[2] * q2) * inv_det;
-                if (in_vector) {
-                    if (dist > 0.0 && dist < prev_dist) {
-                        prev_dist = dist;
-                        near_idx = ind;
-                        break; // exit on first intersection
-                    }
-                } else {
-                    if (std::abs(dist) < std::abs(prev_dist)) {
-                        prev_dist = dist;
-                        near_idx = ind;
-                        break; // exit on first intersection
-                    }
-                }
-            }
-        }
-
-        if (no_inf && near_idx == -1) { // no intersection and no inf
-            dists[i] = 0.0;
-            near_ind[i] = near_idx;
-        } else {
-            dists[i] = prev_dist;
-            near_ind[i] = near_idx;
-        }
+        double t;
+        const int hit = pyacvd_bvh::bvh_trace_ray(bvh, origin, dir, in_vector, t);
+        dists[i] = (hit == -1) ? T(0.0) : static_cast<T>(t);
+        near_ind[i] = hit;
     }
 
     return nb::make_tuple(dists_arr, near_ind_arr);

--- a/src/pyacvd/_clustering.pyi
+++ b/src/pyacvd/_clustering.pyi
@@ -57,12 +57,8 @@ def ray_trace(
     source_n: NDArray[T],
     target_v: NDArray[T],
     target_f: NDArray_INT32,
-    idx: NDArray_UINT32,
-    no_inf: bool,
-    num_threads: int,
-    out_of_bounds_idx: int,
     in_vector: bool,
-) -> NDArray[T]: ...
+) -> Tuple[NDArray[T], NDArray_INT32]: ...
 def neighbors_from_trimesh(
     n_points: int,
     faces: NDArray_INT32,

--- a/src/pyacvd/clustering.py
+++ b/src/pyacvd/clustering.py
@@ -30,8 +30,6 @@ T = TypeVar("T", np.float32, np.float64)
 
 LOG = logging.getLogger(__name__)
 
-MAX_THREADS = 4
-
 # Face indices are int32 through the C extension, so a mesh cannot have more
 # points than an int32 can address
 MAX_POINTS = int(np.iinfo(np.int32).max)
@@ -538,28 +536,35 @@ def ray_trace(
     source_n: NDArray[T],
     target_v: NDArray[T],
     target_f: NDArray_INT32,
-    neigh: NDArray_UINT32,
-    no_inf: bool = True,
-    num_threads: int = 8,
-    out_of_bounds_idx: Optional[int] = None,
     in_vector: bool = False,
-) -> Tuple[NDArray[T], NDArray[T]]:
-    if out_of_bounds_idx is None:
-        out_of_bounds_idx = 0
-    if out_of_bounds_idx == -1:
-        raise ValueError
-    dist, ind = _clustering.ray_trace(
-        source_v,
-        source_n,
-        target_v,
-        target_f,
-        neigh,
-        no_inf,
-        num_threads,
-        out_of_bounds_idx,
-        in_vector,
-    )
-    return dist, ind
+) -> Tuple[NDArray[T], NDArray_INT32]:
+    """Cast a ray from each source point and return where it meets the surface.
+
+    Parameters
+    ----------
+    source_v : numpy.ndarray
+        Origin of each ray, shaped ``(n, 3)``.
+    source_n : numpy.ndarray
+        Direction of each ray, shaped ``(n, 3)`` and of unit length.
+    target_v : numpy.ndarray
+        Vertices of the surface to cast against.
+    target_f : numpy.ndarray
+        Triangular faces of that surface, shaped ``(n, 3)``.
+    in_vector : bool, default: False
+        Only let a ray travel forwards along its direction. By default it
+        travels both ways and takes whichever intersection is nearest its
+        origin.
+
+    Returns
+    -------
+    numpy.ndarray
+        Signed distance along each ray to the surface, or ``0.0`` where the ray
+        meets it nowhere.
+    numpy.ndarray
+        Index of the face each ray hit, or ``-1`` where it hit none.
+
+    """
+    return _clustering.ray_trace(source_v, source_n, target_v, target_f, in_vector)
 
 
 def _unique_row_indices(a: Matrix) -> NDArray_INT32_64:
@@ -647,10 +652,7 @@ def create_mesh(
 
     # Update cluster centroid locations based on intersections
     if moveclus and cnorm is not None:
-        tgt_nbr = min(faces.shape[0] - 1, 1000)
-        fcent = face_centroid_arrays(points, faces)
-        _, ind = neighbors(fcent, ccent, tgt_nbr, sqr_dists=True)
-        dist, _ = ray_trace(ccent, cnorm, points, faces, ind, num_threads=MAX_THREADS)
+        dist, _ = ray_trace(ccent, cnorm, points, faces)
         ccent += cnorm * dist.reshape((-1, 1))
 
     # Ignore faces that do not connect to different clusters

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -1,4 +1,5 @@
 import os
+from typing import Callable
 
 import numpy as np
 import pyacvd
@@ -194,3 +195,230 @@ def test_tri_faces_from_poly_mixed() -> None:
 
     with pytest.raises(ValueError, match="all triangles"):
         clustering._tri_faces_from_poly(mixed)
+
+
+def _brute_force_ray_trace(
+    origins: np.ndarray,
+    dirs: np.ndarray,
+    points: np.ndarray,
+    faces: np.ndarray,
+    in_vector: bool = False,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return the nearest intersection, testing every ray against every face.
+
+    The reference the tree is checked against: same Moller-Trumbore test and same
+    tolerances, none of the traversal.
+    """
+    v0 = points[faces[:, 0]]
+    e1 = points[faces[:, 1]] - v0
+    e2 = points[faces[:, 2]] - v0
+
+    dist = np.zeros(len(origins))
+    hit = np.full(len(origins), -1, dtype=np.int32)
+
+    for i, (origin, direction) in enumerate(zip(origins, dirs)):
+        p = np.cross(direction, e2)
+        det = np.einsum("ij,ij->i", e1, p)
+        ok = np.abs(det) >= 1e-6
+        inv_det = np.divide(1.0, det, out=np.zeros_like(det), where=ok)
+
+        s = origin - v0
+        u = np.einsum("ij,ij->i", s, p) * inv_det
+        ok &= (u >= -1e-6) & (u <= 1.0 + 1e-6)
+
+        q = np.cross(s, e1)
+        v = (q @ direction) * inv_det
+        ok &= (v >= -1e-6) & (u + v <= 1.0 + 1e-6)
+
+        t = np.einsum("ij,ij->i", e2, q) * inv_det
+        if in_vector:
+            ok &= t > 0.0
+        if not ok.any():
+            continue
+
+        key = np.where(ok, t if in_vector else np.abs(t), np.inf)
+        nearest = int(np.argmin(key))
+        dist[i] = t[nearest]
+        hit[i] = nearest
+    return dist, hit
+
+
+def _random_rays(mesh: pv.PolyData, n: int = 300, seed: int = 0) -> tuple[np.ndarray, np.ndarray]:
+    """Random rays over the mesh, originating clear of its surface.
+
+    Deliberately not from its vertices. A ray starting on the surface meets every
+    face of that vertex's fan at zero distance, and which of them is reported is
+    an arbitrary tie that says nothing about whether the traversal is right.
+    """
+    rng = np.random.default_rng(seed)
+    lower, upper = np.array(mesh.bounds).reshape(3, 2).T
+    span = upper - lower
+
+    origins = lower - 0.25 * span + rng.random((n, 3)) * 1.5 * span
+    dirs = rng.normal(size=(n, 3))
+    return origins, dirs / np.linalg.norm(dirs, axis=1, keepdims=True)
+
+
+@pytest.mark.parametrize("in_vector", [False, True], ids=["both_ways", "forwards"])
+@pytest.mark.parametrize(
+    "make_mesh",
+    [
+        lambda: pv.Sphere(),
+        lambda: pv.Cone(resolution=40),
+        lambda: pv.ParametricTorus(),
+        lambda: examples.load_airplane(),
+    ],
+    ids=["sphere", "cone", "torus", "airplane"],
+)
+def test_ray_trace_matches_brute_force(
+    make_mesh: Callable[[], pv.PolyData], in_vector: bool
+) -> None:
+    """The tree must find exactly what testing every face finds."""
+    mesh = make_mesh().triangulate().clean()
+    points = mesh.points.astype(np.float64)
+    faces = clustering._tri_faces_from_poly(mesh)
+    origins, dirs = _random_rays(mesh)
+
+    dist, hit = clustering.ray_trace(origins, dirs, points, faces, in_vector)
+    expected_dist, expected_hit = _brute_force_ray_trace(origins, dirs, points, faces, in_vector)
+
+    assert np.array_equal(hit, expected_hit)
+    assert np.allclose(dist, expected_dist, rtol=0, atol=1e-12)
+    assert hit.max() >= 0, "the rays missed the mesh entirely, so nothing was compared"
+
+
+def _offset_centroid_mesh() -> tuple[np.ndarray, np.ndarray]:
+    """Two faces where the nearer one along the ray has the further centroid.
+
+    The near face contains the ray but is stretched away across the xy plane, so
+    its centroid is 10.2 from the origin against the far face's 5.0. Ordering
+    candidate faces by how near their centroid is therefore offers the far face
+    first.
+    """
+    points = np.array(
+        [
+            [-1.0, -1.0, 1.0],
+            [1.0, -1.0, 1.0],
+            [20.0, 25.0, 1.0],
+            [-1.0, -1.0, 5.0],
+            [1.0, -1.0, 5.0],
+            [0.0, 1.0, 5.0],
+        ]
+    )
+    return points, np.array([[0, 1, 2], [3, 4, 5]], dtype=np.int32)
+
+
+def test_ray_trace_takes_the_nearest_face_not_the_nearest_centroid() -> None:
+    """A ray must stop at the first face it meets.
+
+    Casting against the faces with the nearest centroids and stopping at the
+    first of them that is hit returns the face at 5.0 here, and with it a point
+    projected four units too far.
+    """
+    points, faces = _offset_centroid_mesh()
+    centroid_dist = np.linalg.norm(points[faces].mean(axis=1), axis=1)
+    assert centroid_dist[0] > centroid_dist[1], "the near face must have the further centroid"
+
+    dist, hit = clustering.ray_trace(np.zeros((1, 3)), np.array([[0.0, 0.0, 1.0]]), points, faces)
+
+    assert hit[0] == 0
+    assert dist[0] == pytest.approx(1.0)
+
+
+def test_ray_trace_reaches_past_a_thousand_faces() -> None:
+    """Every face is a candidate, however many there are.
+
+    A fixed candidate list cannot see a face beyond its end. Here the only face
+    the ray meets is the last of several thousand, and all the nearer centroids
+    belong to faces off to one side that it misses.
+    """
+    n = 4000
+    rng = np.random.default_rng(0)
+    decoys = rng.random((n, 3, 3)) * 2.0 + np.array([5.0, 0.0, 0.0])
+    target = np.array([[[-1.0, -1.0, 1.0], [1.0, -1.0, 1.0], [0.0, 1.0, 1.0]]])
+
+    points = np.vstack((decoys, target)).reshape(-1, 3)
+    faces = np.arange(points.shape[0], dtype=np.int32).reshape(-1, 3)
+
+    dist, hit = clustering.ray_trace(np.zeros((1, 3)), np.array([[0.0, 0.0, 1.0]]), points, faces)
+
+    assert hit[0] == n
+    assert dist[0] == pytest.approx(1.0)
+
+
+def test_ray_trace_in_vector_only_travels_forwards() -> None:
+    """A ray restricted to its direction must ignore what lies behind it."""
+    points, faces = _offset_centroid_mesh()
+    origins = np.array([[0.0, 0.0, 3.0]])
+    dirs = np.array([[0.0, 0.0, 1.0]])
+
+    # the near face is two behind, the far face is two ahead
+    both_ways, hit_both = clustering.ray_trace(origins, dirs, points, faces, False)
+    forwards, hit_forwards = clustering.ray_trace(origins, dirs, points, faces, True)
+
+    assert hit_both[0] == 0
+    assert both_ways[0] == pytest.approx(-2.0)
+    assert hit_forwards[0] == 1
+    assert forwards[0] == pytest.approx(2.0)
+
+
+def test_ray_trace_miss_leaves_the_point_alone() -> None:
+    """A ray that meets nothing reports no face and no distance to travel."""
+    points, faces = _offset_centroid_mesh()
+
+    dist, hit = clustering.ray_trace(
+        np.array([[100.0, 100.0, 0.0]]), np.array([[0.0, 0.0, 1.0]]), points, faces
+    )
+
+    assert hit[0] == -1
+    assert dist[0] == 0.0
+
+
+def test_ray_trace_empty_surface() -> None:
+    """Casting against nothing is a miss rather than an error."""
+    dist, hit = clustering.ray_trace(
+        np.zeros((1, 3)),
+        np.array([[0.0, 0.0, 1.0]]),
+        np.zeros((0, 3)),
+        np.zeros((0, 3), dtype=np.int32),
+    )
+
+    assert hit[0] == -1
+    assert dist[0] == 0.0
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_ray_trace_dtypes(dtype: type) -> None:
+    """A float32 surface is traced at the same precision as a float64 one."""
+    points, faces = _offset_centroid_mesh()
+
+    dist, hit = clustering.ray_trace(
+        np.zeros((1, 3), dtype=dtype),
+        np.array([[0.0, 0.0, 1.0]], dtype=dtype),
+        points.astype(dtype),
+        faces,
+    )
+
+    assert dist.dtype == dtype
+    assert hit[0] == 0
+    assert dist[0] == pytest.approx(1.0)
+
+
+def test_create_mesh_projects_onto_the_surface() -> None:
+    """Every point ``moveclus`` moves must end up on the surface.
+
+    The airplane is the mesh in the example set that most exercises this: it is
+    thin, so a cluster normal often runs nearly along a panel rather than across
+    it, and the face the ray meets is regularly not one of those whose centroid
+    is nearest the cluster.
+    """
+    clus = pyacvd.Clustering(examples.load_airplane().triangulate().clean())
+    clus.subdivide(3)
+    clus.cluster(3000)
+
+    moved = clus.create_mesh()
+    _, closest = clus.mesh.find_closest_cell(moved.points, return_closest_point=True)
+    deviation = np.linalg.norm(moved.points - closest, axis=1)
+
+    # relative to the model, which is around 2000 across
+    assert deviation.max() < 1e-6

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -212,6 +212,9 @@ def _brute_force_ray_trace(
     v0 = points[faces[:, 0]]
     e1 = points[faces[:, 1]] - v0
     e2 = points[faces[:, 2]] - v0
+    # the determinant is compared against the area scale of the face, not a
+    # fixed number, exactly as the tree does
+    sqr_scale = (np.cross(e1, e2) ** 2).sum(axis=1)
 
     dist = np.zeros(len(origins))
     hit = np.full(len(origins), -1, dtype=np.int32)
@@ -219,7 +222,7 @@ def _brute_force_ray_trace(
     for i, (origin, direction) in enumerate(zip(origins, dirs)):
         p = np.cross(direction, e2)
         det = np.einsum("ij,ij->i", e1, p)
-        ok = np.abs(det) >= 1e-6
+        ok = det**2 >= 1e-9**2 * sqr_scale
         inv_det = np.divide(1.0, det, out=np.zeros_like(det), where=ok)
 
         s = origin - v0
@@ -344,6 +347,46 @@ def test_ray_trace_reaches_past_a_thousand_faces() -> None:
 
     assert hit[0] == n
     assert dist[0] == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("scale", [1.0, 1e-3, 1e-6], ids=["unit", "milli", "micro"])
+def test_ray_trace_is_independent_of_mesh_scale(scale: float) -> None:
+    """A small mesh must be traced like a large one.
+
+    The Moller-Trumbore determinant carries the area of the face, so comparing
+    it against a fixed number rejects a face for being small rather than for
+    lying along the ray. At the tolerance this replaced, 99.7% of the faces of
+    the Stanford bunny subdivided once were unhittable and its cluster
+    centroids were left where they were.
+    """
+    points, faces = _offset_centroid_mesh()
+
+    dist, hit = clustering.ray_trace(
+        np.zeros((1, 3)), np.array([[0.0, 0.0, 1.0]]), points * scale, faces
+    )
+
+    assert hit[0] == 0
+    assert dist[0] == pytest.approx(scale)
+
+
+def test_ray_trace_ignores_a_face_of_no_area() -> None:
+    """A degenerate face has no plane to meet and must not be reported."""
+    points = np.array(
+        [
+            [-1.0, -1.0, 1.0],
+            [1.0, -1.0, 1.0],
+            [1.0, -1.0, 1.0],  # repeated, so the face is a line
+            [-1.0, -1.0, 5.0],
+            [1.0, -1.0, 5.0],
+            [0.0, 1.0, 5.0],
+        ]
+    )
+    faces = np.array([[0, 1, 2], [3, 4, 5]], dtype=np.int32)
+
+    dist, hit = clustering.ray_trace(np.zeros((1, 3)), np.array([[0.0, 0.0, 1.0]]), points, faces)
+
+    assert hit[0] == 1
+    assert dist[0] == pytest.approx(5.0)
 
 
 def test_ray_trace_in_vector_only_travels_forwards() -> None:


### PR DESCRIPTION
`create_mesh(moveclus=True)` projects each cluster centroid onto the surface along its normal. It did that by taking the 1000 faces whose centroids were nearest the cluster centroid and stopping at the first one the ray hit. Both halves are approximations: the face a ray meets first need not be one whose centroid is near it, and beyond 1000 faces it is not a candidate at all. This builds a BVH over the surface, ported from femorph, and takes the true nearest intersection.

The second commit is the bigger one. The Möller-Trumbore determinant is the sine of the angle between the ray and the plane of the face times twice the area of the face, so rejecting on a fixed `1e-6` threw out small faces regardless of angle: 99.7% of the faces of the bunny subdivided once, whose centroids `moveclus` then could not move at all. Dividing the area back out makes the test scale free, and takes the bunny at 5000 clusters from 32 of its points moving to 4968, and its worst distance from the surface from 5.5e-4 to 1.6e-17. The airplane goes from 1.09 off a model 2000 across to 2.8e-14.

Also 5.9-15x faster on the projection and 4.5-10x on `create_mesh` overall, since a tree walk replaces a k=1000 kd-tree query.

`ray_trace` loses its `neigh`, `no_inf`, `num_threads` and `out_of_bounds_idx` arguments and returns the index of the face hit rather than an index into a candidate list. `MAX_THREADS` goes with it: it fed a `num_threads` parameter the extension never read.

Tests check the tree against a brute-force reference over every face on four meshes in both directions, and pin each case that was wrong: the nearest centroid not being the nearest face, a hit beyond the thousandth candidate, mesh scale, and a face of no area. The airplane test fails on main at 1.09.

Groundwork for #83, which needs the hit face to tell a legitimate projection from a runaway.

Changes drafted by Claude Opus 5 but fully understood by me.
